### PR TITLE
LSP: Modify ParentProcessWatcher to work under Linux.

### DIFF
--- a/LibLsp/lsp/ParentProcessWatcher.h
+++ b/LibLsp/lsp/ParentProcessWatcher.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "LibLsp/JsonRpc/MessageIssue.h"
-
+#include <memory>
 
 class ParentProcessWatcher
 {

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NETWORKS_DETAIL = $(addprefix detail/, uri_advance_parts.o \
 	uri_normalize.o uri_parse.o uri_parse_authority.o uri_resolve.o)
 NETWORK_FILES = $(addprefix uri/, uri.o uri_builder.o uri_errors.o $(NETWORKS_DETAIL))
 LSP_FILES = extention/sct/sct.o general/initialize.o lsp.o lsp_diagnostic.o \
-	ProtocolJsonHandler.o textDocument/textDocument.o markup/Markup.o ParentProcessWatcher.cpp \
+	ProtocolJsonHandler.o textDocument/textDocument.o markup/Markup.o ParentProcessWatcher.o \
 	utils.o working_files.o
 JSONRPC_FILES = TcpServer.o threaded_queue.o WebSocketServer.o RemoteEndPoint.o \
 	Endpoint.o message.o MessageJsonHandler.o serializer.o StreamMessageProducer.o \


### PR DESCRIPTION
This is a follow up commit to #12. I initially did not fix ParentProcessWatcher correctly. This PR should be a fix.