### PR TITLE
Change boost::optional to std::optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ function(lspcpp_set_target_options target)
     set_property(TARGET ${target} PROPERTY CXX_STANDARD_REQUIRED ON)
 
     # Enable C++14 (Required)
-    set_property(TARGET ${target} PROPERTY CXX_STANDARD 14)
+    set_property(TARGET ${target} PROPERTY CXX_STANDARD 17)
 
     set_property(TARGET ${target} PROPERTY CXX_EXTENSIONS OFF)
 

--- a/include/LibLsp/JsonRpc/serializer.h
+++ b/include/LibLsp/JsonRpc/serializer.h
@@ -1,14 +1,10 @@
 #pragma once
 
 #include "macro_map.h"
-#ifdef boost
-#include "optional.hpp"
-#else
-#include <boost/optional.hpp>
-#endif
 
 #include <cassert>
 #include <memory>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -205,9 +201,8 @@ void Reflect(Reader& visitor, SerializeFormat& value);
 void Reflect(Writer& visitor, SerializeFormat& value);
 
 //// Type constructors
-
 template <typename T>
-void Reflect(Reader& visitor, boost::optional<T>& value) {
+void Reflect(Reader& visitor, std::optional<T>& value) {
 	if (visitor.IsNull()) {
 		visitor.GetNull();
 		return;
@@ -217,7 +212,7 @@ void Reflect(Reader& visitor, boost::optional<T>& value) {
 	value = std::move(real_value);
 }
 template <typename T>
-void Reflect(Writer& visitor, boost::optional<T>& value) {
+void Reflect(Writer& visitor, std::optional<T>& value) {
 	if (value)
 		Reflect(visitor, *value);
 	else
@@ -226,7 +221,7 @@ void Reflect(Writer& visitor, boost::optional<T>& value) {
 
 
 template <typename T>
-void ReflectMember(Writer& visitor, const char* name, boost::optional<T>& value) {
+void ReflectMember(Writer& visitor, const char* name, std::optional<T>& value) {
 	// For TypeScript optional property key?: value in the spec,
 	// We omit both key and value if value is std::nullopt (null) for JsonWriter
 	// to reduce output. But keep it for other serialization formats.
@@ -235,7 +230,6 @@ void ReflectMember(Writer& visitor, const char* name, boost::optional<T>& value)
 		Reflect(visitor, value);
 	}
 }
-
 
 
 template <typename T>
@@ -329,7 +323,7 @@ void ReflectMember(Writer& visitor, const char* name, T& value) {
 }
 
 template<class _Ty1, class _Ty2>
-void Reflect(Writer& visitor, std::pair<  boost::optional<_Ty1>, boost::optional<_Ty2> >& value)
+void Reflect(Writer& visitor, std::pair<  std::optional<_Ty1>, std::optional<_Ty2> >& value)
 {
 	if (value.first)
 	{
@@ -341,7 +335,7 @@ void Reflect(Writer& visitor, std::pair<  boost::optional<_Ty1>, boost::optional
 	}
 }
 template<class _Ty2>
-void Reflect(Reader& visitor, std::pair<  boost::optional<bool>, boost::optional<_Ty2> >& value)
+void Reflect(Reader& visitor, std::pair<  std::optional<bool>, std::optional<_Ty2> >& value)
 {
 	if(visitor.IsBool())
 	{
@@ -352,7 +346,7 @@ void Reflect(Reader& visitor, std::pair<  boost::optional<bool>, boost::optional
 	Reflect(visitor, value.second);
 }
 template<class _Ty2>
-void Reflect(Reader& visitor, std::pair<  boost::optional<std::string>, boost::optional<_Ty2> >& value)
+void Reflect(Reader& visitor, std::pair<  std::optional<std::string>, std::optional<_Ty2> >& value)
 {
 	if (visitor.IsString())
 	{
@@ -365,7 +359,7 @@ void Reflect(Reader& visitor, std::pair<  boost::optional<std::string>, boost::o
 
 
 template<class _Ty1, class _Ty2>
-void Reflect(Reader& visitor, std::pair<  boost::optional<_Ty1>, boost::optional<_Ty2> >& value)
+void Reflect(Reader& visitor, std::pair<  std::optional<_Ty1>, std::optional<_Ty2> >& value)
 {
 	try
 	{

--- a/include/LibLsp/JsonRpc/threaded_queue.h
+++ b/include/LibLsp/JsonRpc/threaded_queue.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <boost/optional/optional.hpp>
+#include <optional>
 #include <algorithm>
 #include <atomic>
 #include <condition_variable>
@@ -156,7 +156,7 @@ struct ThreadedQueue : public BaseThreadQueue {
 
   // Get the first element from the queue without blocking. Returns a null
   // value if the queue is empty.
-  boost::optional<T> TryDequeue(bool priority) {
+  std::optional<T> TryDequeue(bool priority) {
     std::lock_guard<std::mutex> lock(mutex);
 
     auto pop = [&](std::deque<T>* q) {
@@ -167,7 +167,7 @@ struct ThreadedQueue : public BaseThreadQueue {
     };
 
     auto get_result = [&](std::deque<T>* first,
-                          std::deque<T>* second) -> boost::optional<T> {
+                          std::deque<T>* second) -> std::optional<T> {
       if (!first->empty())
         return pop(first);
       if (!second->empty())

--- a/include/LibLsp/lsp/ClientPreferences.h
+++ b/include/LibLsp/lsp/ClientPreferences.h
@@ -79,14 +79,14 @@ public:
 		return v3supported && isDynamicRegistrationSupported(textDocument.signatureHelp);
 	}
 	template<typename  T>
-	static bool isDynamicRegistrationSupported(boost::optional<T>& capability)
+	static bool isDynamicRegistrationSupported(std::optional<T>& capability)
 	{
 		if(capability)
 			return (capability.value().dynamicRegistration.value());
 		return false;
 	}
 	
-	bool isTrue(const boost::optional<bool>& value)
+	bool isTrue(const std::optional<bool>& value)
 	{
 		return  value.get_value_or(false);
 	}
@@ -282,8 +282,8 @@ public:
 		return false;
 	}
 
-	bool isTagSupported(const boost::optional < std::pair<boost::optional<bool>,
-		boost::optional<DiagnosticsTagSupport> > >& tagSupport) {
+	bool isTagSupported(const std::optional < std::pair<std::optional<bool>,
+		std::optional<DiagnosticsTagSupport> > >& tagSupport) {
 		if(tagSupport)
 		{
 			auto &v = tagSupport.value();

--- a/include/LibLsp/lsp/CodeActionParams.h
+++ b/include/LibLsp/lsp/CodeActionParams.h
@@ -77,7 +77,7 @@ struct lsCodeActionContext {
 	 *
 	 * See {@link CodeActionKind} for allowed values.
 	 */
-	boost::optional<std::vector<std::string>> only;
+	std::optional<std::vector<std::string>> only;
 
 	MAKE_SWAP_METHOD(lsCodeActionContext,
 		diagnostics, only);

--- a/include/LibLsp/lsp/ExecuteCommandParams.h
+++ b/include/LibLsp/lsp/ExecuteCommandParams.h
@@ -13,7 +13,7 @@ struct ExecuteCommandParams {
 	 * The arguments are typically specified when a command is returned from the server to the client.
 	 * Example requests that return a command are textDocument/codeAction or textDocument/codeLens.
 	 */
-	boost::optional<std::vector<lsp::Any>>  arguments;
+	std::optional<std::vector<lsp::Any>>  arguments;
 	
 	MAKE_SWAP_METHOD(ExecuteCommandParams, command, arguments);
 };

--- a/include/LibLsp/lsp/ResourceOperation.h
+++ b/include/LibLsp/lsp/ResourceOperation.h
@@ -18,12 +18,12 @@ struct CreateFileOptions{
 	/**
 	 * Overwrite existing file. Overwrite wins over `ignoreIfExists`
 	 */
-	boost::optional<bool>  overwrite = false;
+	std::optional<bool>  overwrite = false;
 
 	/**
 	 * Ignore if exists.
 	 */
-	boost::optional< bool> ignoreIfExists =false;
+	std::optional< bool> ignoreIfExists =false;
 	
 	MAKE_SWAP_METHOD(CreateFileOptions, overwrite, ignoreIfExists)
 };
@@ -39,7 +39,7 @@ struct lsCreateFile :public ResourceOperation {
 	/**
 	 * Additional options
 	 */
-	boost::optional<CreateFileOptions>  options;
+	std::optional<CreateFileOptions>  options;
 
 
 	/**
@@ -47,7 +47,7 @@ struct lsCreateFile :public ResourceOperation {
 	 *
 	 * @since 3.16.0
 	 */
-	boost::optional<lsChangeAnnotationIdentifier> annotationId;
+	std::optional<lsChangeAnnotationIdentifier> annotationId;
 	
 	MAKE_SWAP_METHOD(lsCreateFile, kind, uri, options, annotationId)
 };
@@ -58,12 +58,12 @@ struct DeleteFileOptions {
 	/**
 	 * Delete the content recursively if a folder is denoted.
 	 */
-	boost::optional<bool>  recursive = false;
+	std::optional<bool>  recursive = false;
 
 	/**
 	 * Ignore the operation if the file doesn't exist.
 	 */
-	boost::optional<bool> ignoreIfNotExists = false;
+	std::optional<bool> ignoreIfNotExists = false;
 
 
 	MAKE_SWAP_METHOD(DeleteFileOptions, recursive, ignoreIfNotExists);
@@ -81,7 +81,7 @@ struct lsDeleteFile :public ResourceOperation {
 	/**
 	 * Delete options.
 	 */
-	boost::optional<DeleteFileOptions>  options;
+	std::optional<DeleteFileOptions>  options;
 
 	MAKE_SWAP_METHOD(lsDeleteFile, kind, uri, options);
 };
@@ -104,14 +104,14 @@ struct lsRenameFile :public ResourceOperation {
 	/**
 	 * Rename options.
 	 */
-	boost::optional<RenameFileOptions>  options;
+	std::optional<RenameFileOptions>  options;
 
 	/**
 	 * An optional annotation identifer describing the operation.
 	 *
 	 * @since 3.16.0
 	 */
-	boost::optional<lsChangeAnnotationIdentifier> annotationId;
+	std::optional<lsChangeAnnotationIdentifier> annotationId;
 	
 	MAKE_SWAP_METHOD(lsRenameFile, kind, oldUri, newUri, options, annotationId)
 };

--- a/include/LibLsp/lsp/extention/jdtls/getMoveDestinations.h
+++ b/include/LibLsp/lsp/extention/jdtls/getMoveDestinations.h
@@ -35,7 +35,7 @@ struct MoveParams {
 	/**
 	 * The code action params when the move operation is triggered.
 	 */
-	boost::optional<lsCodeActionParams>  params;
+	std::optional<lsCodeActionParams>  params;
 	/**
 	 * The possible destination: a folder/package, class, instanceDeclaration.
 	 */

--- a/include/LibLsp/lsp/extention/jdtls/getRefactorEdit.h
+++ b/include/LibLsp/lsp/extention/jdtls/getRefactorEdit.h
@@ -47,7 +47,7 @@ struct GetRefactorEditParams
 	std::string command;
 	std::vector<lsp::Any>  commandArguments;
 	lsCodeActionParams context;
-	boost::optional<lsFormattingOptions> options;
+	std::optional<lsFormattingOptions> options;
 	MAKE_SWAP_METHOD(GetRefactorEditParams, command, context, options);
 };
 MAKE_REFLECT_STRUCT(GetRefactorEditParams, command, context, options);
@@ -65,9 +65,9 @@ struct RefactorWorkspaceEdit {
 	 * command, first the edit is executed and then the command.
 	 */
 	
-	boost::optional<std::string> errorMessage;
+	std::optional<std::string> errorMessage;
 	
-	boost::optional < lsCommandWithAny > command;
+	std::optional < lsCommandWithAny > command;
 	
 	MAKE_SWAP_METHOD(RefactorWorkspaceEdit, edit, command, errorMessage)
 };

--- a/include/LibLsp/lsp/extention/jdtls/searchSymbols.h
+++ b/include/LibLsp/lsp/extention/jdtls/searchSymbols.h
@@ -13,9 +13,9 @@
 
 struct SearchSymbolParams :public WorkspaceSymbolParams
 {
-	boost::optional<std::string>  projectName;
-	boost::optional< bool >sourceOnly;
-	boost::optional< int> maxResults;
+	std::optional<std::string>  projectName;
+	std::optional< bool >sourceOnly;
+	std::optional< int> maxResults;
 	MAKE_SWAP_METHOD(SearchSymbolParams, query, projectName, sourceOnly, maxResults);
 };
 MAKE_REFLECT_STRUCT(SearchSymbolParams, query, projectName, sourceOnly, maxResults);

--- a/include/LibLsp/lsp/extention/sonarlint/protocol.h
+++ b/include/LibLsp/lsp/extention/sonarlint/protocol.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <string>
-#include <boost/optional.hpp>
+#include <optional>
 #include "LibLsp/JsonRpc/RequestInMessage.h"
 #include "LibLsp/lsp/lsDocumentUri.h"
 #include "LibLsp/lsp/lsAny.h"
@@ -18,8 +18,8 @@ struct LintRule
 		return name + " (" + key + ")";
 	}
 	bool activeByDefault = true;
-	boost::optional<std::string> severity;
-	boost::optional<std::string> type;
+	std::optional<std::string> severity;
+	std::optional<std::string> type;
 	int icon_index = -1;
 	MAKE_SWAP_METHOD(LintRule, key, name, activeByDefault, severity, type);
 
@@ -29,25 +29,25 @@ MAKE_REFLECT_STRUCT(LintRule, key, name, activeByDefault, severity, type);
 
 struct RuleParameter {
 	std::string name;
-	boost::optional<std::string>  description;
-	boost::optional<std::string> defaultValue;
+	std::optional<std::string>  description;
+	std::optional<std::string> defaultValue;
 
 };
 MAKE_REFLECT_STRUCT(RuleParameter, name, description, defaultValue);
 
 struct ShowRuleDescriptionParams {
 
-	boost::optional<std::string> key;
+	std::optional<std::string> key;
 
-	boost::optional<std::string> name;
+	std::optional<std::string> name;
 
-	boost::optional<std::string> htmlDescription;
+	std::optional<std::string> htmlDescription;
 
-	boost::optional<std::string>  type;
+	std::optional<std::string>  type;
 
-	boost::optional<std::string>  severity;
+	std::optional<std::string>  severity;
 
-	boost::optional< std::vector<RuleParameter> >   parameters;
+	std::optional< std::vector<RuleParameter> >   parameters;
 	MAKE_SWAP_METHOD(ShowRuleDescriptionParams, key, name, htmlDescription, type, severity, parameters)
 
 
@@ -82,7 +82,7 @@ struct ServerConnectionSettings {
 	std::string connectionId;
 	std::string serverUrl;
 	std::string token;
-	boost::optional<std::string> organizationKey;
+	std::optional<std::string> organizationKey;
 	MAKE_SWAP_METHOD(ServerConnectionSettings, connectionId, serverUrl, token, organizationKey)
 
 };
@@ -114,28 +114,28 @@ struct RuleSetting
 			off();
 		}
 	}
-	boost::optional< std::map<std::string, std::string > > parameters;
+	std::optional< std::map<std::string, std::string > > parameters;
 };
 MAKE_REFLECT_STRUCT(RuleSetting, level, parameters)
 
 struct ConsoleParams
 {
-	boost::optional < bool >showAnalyzerLogs;
-	boost::optional < bool >showVerboseLogs;
+	std::optional < bool >showAnalyzerLogs;
+	std::optional < bool >showVerboseLogs;
 	MAKE_SWAP_METHOD(ConsoleParams, showAnalyzerLogs, showVerboseLogs)
 };
 MAKE_REFLECT_STRUCT(ConsoleParams, showAnalyzerLogs, showVerboseLogs)
 
 struct SonarLintWorkspaceSettings
 {
-	boost::optional < bool > disableTelemetry;
-	boost::optional < std::map<std::string, ServerConnectionSettings> >connectedMode;
-	boost::optional<std::map<std::string, RuleSetting>>  rules;
-	boost::optional<ConsoleParams> output;
+	std::optional < bool > disableTelemetry;
+	std::optional < std::map<std::string, ServerConnectionSettings> >connectedMode;
+	std::optional<std::map<std::string, RuleSetting>>  rules;
+	std::optional<ConsoleParams> output;
 
-	boost::optional<std::string >  pathToNodeExecutable;
+	std::optional<std::string >  pathToNodeExecutable;
 
-	boost::optional< std::map<std::string, std::string > > getConfigurationParameters(const std::string& ruleKey);
+	std::optional< std::map<std::string, std::string > > getConfigurationParameters(const std::string& ruleKey);
 
 
 };

--- a/include/LibLsp/lsp/general/InitializeParams.h
+++ b/include/LibLsp/lsp/general/InitializeParams.h
@@ -7,7 +7,7 @@
 
 struct ClientInfo {
 	std::string name;
-	boost::optional<std::string> version;
+	std::optional<std::string> version;
 	
 	MAKE_SWAP_METHOD(ClientInfo,name,version);
 };
@@ -18,14 +18,14 @@ struct lsInitializeParams {
   // the server. Is null if the process has not been started by another process.
   // If the parent process is not alive then the server should exit (see exit
   // notification) its process.
-  boost::optional<int> processId;
+  std::optional<int> processId;
 	
   /**
    * Information about the client
    *
    * @since 3.15.0
    */
-  boost::optional<ClientInfo> clientInfo;
+  std::optional<ClientInfo> clientInfo;
   /**
    * The locale the client is currently showing the user interface
    * in. This must not necessarily be the locale of the operating
@@ -36,32 +36,32 @@ struct lsInitializeParams {
    *
    * @since 3.16.0
    */
-  boost::optional<std::string> locale;
+  std::optional<std::string> locale;
 	
   // The rootPath of the workspace. Is null
   // if no folder is open.
   //
   // @deprecated in favour of rootUri.
-  boost::optional<std::string> rootPath;
+  std::optional<std::string> rootPath;
 
   // The rootUri of the workspace. Is null if no
   // folder is open. If both `rootPath` and `rootUri` are set
   // `rootUri` wins.
-  boost::optional<lsDocumentUri> rootUri;
+  std::optional<lsDocumentUri> rootUri;
 
   // User provided initialization options.
-  boost::optional<lsp::Any> initializationOptions;
+  std::optional<lsp::Any> initializationOptions;
 
   // The capabilities provided by the client (editor or tool)
   lsClientCapabilities capabilities;
 
 
   /**
- * An boost::optional extension to the protocol.
+ * An std::optional extension to the protocol.
  * To tell the server what client (editor) is talking to it.
  */
  // @Deprecated
-  boost::optional< std::string >clientName;
+  std::optional< std::string >clientName;
 
 
 	
@@ -85,7 +85,7 @@ struct lsInitializeParams {
  *
  * Since 3.6.0
  */
-  boost::optional< std::vector<WorkspaceFolder> >  workspaceFolders;
+  std::optional< std::vector<WorkspaceFolder> >  workspaceFolders;
 
   MAKE_SWAP_METHOD(lsInitializeParams,
       processId,

--- a/include/LibLsp/lsp/general/exit.h
+++ b/include/LibLsp/lsp/general/exit.h
@@ -4,4 +4,4 @@
 /**
  * A notification to ask the server to exit its process.
  */
-DEFINE_NOTIFICATION_TYPE(Notify_Exit, boost::optional<JsonNull>, "exit");
+DEFINE_NOTIFICATION_TYPE(Notify_Exit, std::optional<JsonNull>, "exit");

--- a/include/LibLsp/lsp/general/lsClientCapabilities.h
+++ b/include/LibLsp/lsp/general/lsClientCapabilities.h
@@ -18,7 +18,7 @@ struct MarkdownClientCapabilities {
 	/**
 	 * The version of the parser.
 	 */
-	boost::optional<std::string>  version;
+	std::optional<std::string>  version;
 	MAKE_SWAP_METHOD(MarkdownClientCapabilities, parser, version)
 	
 };
@@ -26,19 +26,19 @@ MAKE_REFLECT_STRUCT(MarkdownClientCapabilities, parser, version)
 
 struct lsClientCapabilities {
   // Workspace specific client capabilities.
-  boost::optional<lsWorkspaceClientCapabilites> workspace;
+  std::optional<lsWorkspaceClientCapabilites> workspace;
 
   // Text document specific client capabilities.
-  boost::optional<lsTextDocumentClientCapabilities> textDocument;
+  std::optional<lsTextDocumentClientCapabilities> textDocument;
 
   /**
 	* Window specific client capabilities.
   */
-  boost::optional<lsp::Any>  window;
+  std::optional<lsp::Any>  window;
   /**
    * Experimental client capabilities.
    */
-  boost::optional<lsp::Any>  experimental;
+  std::optional<lsp::Any>  experimental;
 
   MAKE_SWAP_METHOD(lsClientCapabilities, workspace, textDocument, window, experimental)
 };

--- a/include/LibLsp/lsp/general/lsServerCapabilities.h
+++ b/include/LibLsp/lsp/general/lsServerCapabilities.h
@@ -10,7 +10,7 @@
 #include "LibLsp/lsp/textDocument/SemanticTokens.h"
 
 
-extern void Reflect(Reader&, std::pair<boost::optional<lsTextDocumentSyncKind>, boost::optional<lsTextDocumentSyncOptions> >&);
+extern void Reflect(Reader&, std::pair<std::optional<lsTextDocumentSyncKind>, std::optional<lsTextDocumentSyncOptions> >&);
 
 //
  // Code Action options.
@@ -32,7 +32,7 @@ struct CodeLensOptions : WorkDoneProgressOptions {
 	//
 	 // Code lens has a resolve provider as well.
 	 //
-	boost::optional<bool> resolveProvider ;
+	std::optional<bool> resolveProvider ;
 	MAKE_SWAP_METHOD(CodeLensOptions, workDoneProgress, resolveProvider);
 };
 MAKE_REFLECT_STRUCT(CodeLensOptions, workDoneProgress, resolveProvider)
@@ -56,7 +56,7 @@ struct RenameOptions : WorkDoneProgressOptions {
 	//
 	 // Renames should be checked and tested before being executed.
 	 //
-	boost::optional<bool> prepareProvider;
+	std::optional<bool> prepareProvider;
 	MAKE_SWAP_METHOD(RenameOptions, workDoneProgress, prepareProvider);
 };
 MAKE_REFLECT_STRUCT(RenameOptions,workDoneProgress,prepareProvider)
@@ -65,11 +65,11 @@ struct DocumentFilter{
 	//
 	 // A language id, like `typescript`.
 	 //
-	boost::optional<std::string> language;
+	std::optional<std::string> language;
 	//
 	 // A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
 	 //
-	boost::optional<std::string>scheme;
+	std::optional<std::string>scheme;
 	//
 	 // A glob pattern, like `*.{ts,js}`.
 	 //
@@ -85,7 +85,7 @@ struct DocumentFilter{
 	 //   (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but
 	 //   not `example.0`)
 	 //
-	boost::optional<std::string>pattern;
+	std::optional<std::string>pattern;
 	MAKE_SWAP_METHOD(DocumentFilter, language, scheme, pattern)
 };
 MAKE_REFLECT_STRUCT(DocumentFilter, language, scheme, pattern)
@@ -96,7 +96,7 @@ using DocumentSelector = std::vector<DocumentFilter>;
 // Document link options
 struct lsDocumentLinkOptions :WorkDoneProgressOptions {
 	// Document links have a resolve provider as well.
-	boost::optional<bool> resolveProvider;
+	std::optional<bool> resolveProvider;
 	MAKE_SWAP_METHOD(lsDocumentLinkOptions, workDoneProgress, resolveProvider);
 };
 MAKE_REFLECT_STRUCT(lsDocumentLinkOptions, workDoneProgress,resolveProvider);
@@ -116,7 +116,7 @@ struct TextDocumentRegistrationOptions
  // A document selector to identify the scope of the registration. If set to null
  // the document selector provided on the client side will be used.
  //
-	boost::optional<DocumentSelector>  documentSelector;
+	std::optional<DocumentSelector>  documentSelector;
 
 	MAKE_SWAP_METHOD(TextDocumentRegistrationOptions, documentSelector);
 };
@@ -131,7 +131,7 @@ struct StaticRegistrationOptions :public TextDocumentRegistrationOptions
 	 // The id used to register the request. The id can be used to deregister
 	 // the request again. See also Registration#id.
 	 //
-	boost::optional<std::string> id;
+	std::optional<std::string> id;
 	MAKE_SWAP_METHOD(StaticRegistrationOptions, documentSelector, id)
 };
 MAKE_REFLECT_STRUCT(StaticRegistrationOptions, documentSelector,id)
@@ -146,7 +146,7 @@ struct WorkspaceFoldersOptions {
 	//
 	 // The server has support for workspace folders
 	 //
-	boost::optional<bool>  supported;
+	std::optional<bool>  supported;
 
 	//
 	 // Whether the server wants to receive workspace folder
@@ -157,7 +157,7 @@ struct WorkspaceFoldersOptions {
 	 // side. The ID can be used to unregister for these events
 	 // using the `client/unregisterCapability` request.
 	 //
-	boost::optional<std::pair<  boost::optional<std::string>, boost::optional<bool> > > changeNotifications;
+	std::optional<std::pair<  std::optional<std::string>, std::optional<bool> > > changeNotifications;
 	MAKE_SWAP_METHOD(WorkspaceFoldersOptions, supported, changeNotifications);
 };
 MAKE_REFLECT_STRUCT(WorkspaceFoldersOptions, supported, changeNotifications);
@@ -185,7 +185,7 @@ struct lsFileOperationPatternOptions {
 	//
 	 // The pattern should be matched ignoring casing.
 	 //
-	boost::optional<bool> ignoreCase;
+	std::optional<bool> ignoreCase;
 	MAKE_SWAP_METHOD(lsFileOperationPatternOptions, ignoreCase)
 };
 MAKE_REFLECT_STRUCT(lsFileOperationPatternOptions, ignoreCase)
@@ -216,12 +216,12 @@ struct lsFileOperationPattern {
 	 //
 	 // Matches both if undefined.
 	 //
-	boost::optional<lsFileOperationPatternKind> matches;
+	std::optional<lsFileOperationPatternKind> matches;
 
 	//
 	 // Additional options used during matching.
 	 //
-	boost::optional<lsFileOperationPatternOptions> options ;
+	std::optional<lsFileOperationPatternOptions> options ;
 	MAKE_SWAP_METHOD(lsFileOperationPattern, glob, matches, options)
 };
 MAKE_REFLECT_STRUCT(lsFileOperationPattern, glob, matches, options)
@@ -236,12 +236,12 @@ struct lsFileOperationFilter {
 	//
 	 // A Uri like `file` or `untitled`.
 	 //
-	boost::optional<std::string>  scheme;
+	std::optional<std::string>  scheme;
 
 	//
 	 // The actual file operation pattern.
 	 //
-	boost::optional<lsFileOperationPattern>	pattern;
+	std::optional<lsFileOperationPattern>	pattern;
 	MAKE_SWAP_METHOD(lsFileOperationFilter, scheme, pattern)
 };
 MAKE_REFLECT_STRUCT(lsFileOperationFilter, scheme, pattern)
@@ -254,7 +254,7 @@ struct lsFileOperationRegistrationOptions {
 	//
 	 // The actual filters.
 	 //
-	boost::optional<std::vector<lsFileOperationFilter>> filters;
+	std::optional<std::vector<lsFileOperationFilter>> filters;
 	MAKE_SWAP_METHOD(lsFileOperationRegistrationOptions, filters)
 };
 MAKE_REFLECT_STRUCT(lsFileOperationRegistrationOptions, filters)
@@ -279,38 +279,38 @@ struct WorkspaceServerCapabilities {
 		 // The server is interested in receiving didCreateFiles
 		 // notifications.
 		 //
-		boost::optional<lsFileOperationRegistrationOptions> didCreate;
+		std::optional<lsFileOperationRegistrationOptions> didCreate;
 
 		//
 		 // The server is interested in receiving willCreateFiles requests.
 		 //
-		boost::optional<lsFileOperationRegistrationOptions> willCreate;
+		std::optional<lsFileOperationRegistrationOptions> willCreate;
 
 		//
 		 // The server is interested in receiving didRenameFiles
 		 // notifications.
 		 //
-		boost::optional<lsFileOperationRegistrationOptions> didRename;
+		std::optional<lsFileOperationRegistrationOptions> didRename;
 
 		//
 		 // The server is interested in receiving willRenameFiles requests.
 		 //
-		boost::optional<lsFileOperationRegistrationOptions> willRename;
+		std::optional<lsFileOperationRegistrationOptions> willRename;
 
 		//
 		 // The server is interested in receiving didDeleteFiles file
 		 // notifications.
 		 //
-		boost::optional<lsFileOperationRegistrationOptions> didDelete;
+		std::optional<lsFileOperationRegistrationOptions> didDelete;
 
 		//
 		 // The server is interested in receiving willDeleteFiles file
 		 // requests.
 		 //
-		boost::optional<lsFileOperationRegistrationOptions> willDelete;
+		std::optional<lsFileOperationRegistrationOptions> willDelete;
 		MAKE_SWAP_METHOD(lsFileOperations, didCreate, willCreate, didRename, willRename, didDelete, willDelete)
 	};
-	boost::optional<lsFileOperations>fileOperations;
+	std::optional<lsFileOperations>fileOperations;
 
 
 	MAKE_SWAP_METHOD(WorkspaceServerCapabilities, workspaceFolders, fileOperations)
@@ -356,24 +356,24 @@ struct SemanticTokensWithRegistrationOptions
 	 // Server supports providing semantic tokens for a specific range
 	 // of a document.
 	 //
-	boost::optional< std::pair< boost::optional<bool>, boost::optional<lsp::Any> > >  range;
+	std::optional< std::pair< std::optional<bool>, std::optional<lsp::Any> > >  range;
 
 	//
 	 // Server supports providing semantic tokens for a full document.
 	 //
-	boost::optional< std::pair< boost::optional<bool>,
-	boost::optional<SemanticTokensServerFull> > >  full;
+	std::optional< std::pair< std::optional<bool>,
+	std::optional<SemanticTokensServerFull> > >  full;
 
 	//
 	 // A document selector to identify the scope of the registration. If set to null
 	 // the document selector provided on the client side will be used.
 	 //
-	boost::optional < std::vector<DocumentFilter> > documentSelector;
+	std::optional < std::vector<DocumentFilter> > documentSelector;
 	//
 	 // The id used to register the request. The id can be used to deregister
 	 // the request again. See also Registration#id.
 	 //
-	boost::optional<std::string> id;
+	std::optional<std::string> id;
 	MAKE_SWAP_METHOD(SemanticTokensWithRegistrationOptions, legend, range, full, documentSelector, id)
 };
 MAKE_REFLECT_STRUCT(SemanticTokensWithRegistrationOptions, legend, range, full, documentSelector ,id)
@@ -385,20 +385,20 @@ struct lsServerCapabilities {
 	// defining each notification or for backwards compatibility the
 
 	// TextDocumentSyncKind number.
-	boost::optional< std::pair<boost::optional<lsTextDocumentSyncKind>,
-	boost::optional<lsTextDocumentSyncOptions> >> textDocumentSync;
+	std::optional< std::pair<std::optional<lsTextDocumentSyncKind>,
+	std::optional<lsTextDocumentSyncOptions> >> textDocumentSync;
 
 	// The server provides hover support.
-	boost::optional<bool>  hoverProvider;
+	std::optional<bool>  hoverProvider;
 
 	// The server provides completion support.
-	boost::optional < lsCompletionOptions > completionProvider;
+	std::optional < lsCompletionOptions > completionProvider;
 
 	// The server provides signature help support.
-	boost::optional < lsSignatureHelpOptions > signatureHelpProvider;
+	std::optional < lsSignatureHelpOptions > signatureHelpProvider;
 
 	// The server provides goto definition support.
-	boost::optional< std::pair< boost::optional<bool>, boost::optional<WorkDoneProgressOptions> > > definitionProvider;
+	std::optional< std::pair< std::optional<bool>, std::optional<WorkDoneProgressOptions> > > definitionProvider;
 
 
   //
@@ -406,44 +406,44 @@ struct lsServerCapabilities {
    //
    // Since 3.6.0
    //
-	boost::optional< std::pair< boost::optional<bool>, boost::optional<StaticRegistrationOptions> > > typeDefinitionProvider ;
+	std::optional< std::pair< std::optional<bool>, std::optional<StaticRegistrationOptions> > > typeDefinitionProvider ;
 
 	// The server provides implementation support.
-	boost::optional< std::pair< boost::optional<bool>, boost::optional<StaticRegistrationOptions> > >  implementationProvider ;
+	std::optional< std::pair< std::optional<bool>, std::optional<StaticRegistrationOptions> > >  implementationProvider ;
 
 	// The server provides find references support.
-	boost::optional< std::pair< boost::optional<bool>, boost::optional<WorkDoneProgressOptions> > > referencesProvider ;
+	std::optional< std::pair< std::optional<bool>, std::optional<WorkDoneProgressOptions> > > referencesProvider ;
 
 	// The server provides document highlight support.
-	boost::optional< std::pair< boost::optional<bool>, boost::optional<WorkDoneProgressOptions> > > documentHighlightProvider ;
+	std::optional< std::pair< std::optional<bool>, std::optional<WorkDoneProgressOptions> > > documentHighlightProvider ;
 
 	// The server provides document symbol support.
-	boost::optional< std::pair< boost::optional<bool>, boost::optional<WorkDoneProgressOptions> > > documentSymbolProvider ;
+	std::optional< std::pair< std::optional<bool>, std::optional<WorkDoneProgressOptions> > > documentSymbolProvider ;
 
 	// The server provides workspace symbol support.
-	boost::optional< std::pair< boost::optional<bool>, boost::optional<WorkDoneProgressOptions> > > workspaceSymbolProvider ;
+	std::optional< std::pair< std::optional<bool>, std::optional<WorkDoneProgressOptions> > > workspaceSymbolProvider ;
 
 	// The server provides code actions.
-	boost::optional< std::pair< boost::optional<bool>, boost::optional<CodeActionOptions> > > codeActionProvider ;
+	std::optional< std::pair< std::optional<bool>, std::optional<CodeActionOptions> > > codeActionProvider ;
 
 	// The server provides code lens.
-	boost::optional<CodeLensOptions> codeLensProvider;
+	std::optional<CodeLensOptions> codeLensProvider;
 
 	// The server provides document formatting.
-	boost::optional< std::pair< boost::optional<bool>, boost::optional<WorkDoneProgressOptions> > > documentFormattingProvider ;
+	std::optional< std::pair< std::optional<bool>, std::optional<WorkDoneProgressOptions> > > documentFormattingProvider ;
 
 	// The server provides document range formatting.
-	boost::optional< std::pair< boost::optional<bool>, boost::optional<WorkDoneProgressOptions> > > documentRangeFormattingProvider ;
+	std::optional< std::pair< std::optional<bool>, std::optional<WorkDoneProgressOptions> > > documentRangeFormattingProvider ;
 
 	// The server provides document formatting on typing.
-	boost::optional<lsDocumentOnTypeFormattingOptions> documentOnTypeFormattingProvider;
+	std::optional<lsDocumentOnTypeFormattingOptions> documentOnTypeFormattingProvider;
 
 	// The server provides rename support.
-	boost::optional< std::pair< boost::optional<bool>, boost::optional<RenameOptions> > >  renameProvider;
+	std::optional< std::pair< std::optional<bool>, std::optional<RenameOptions> > >  renameProvider;
 
 
 	// The server provides document link support.
-	boost::optional<lsDocumentLinkOptions > documentLinkProvider;
+	std::optional<lsDocumentLinkOptions > documentLinkProvider;
 
 
 	//
@@ -451,7 +451,7 @@ struct lsServerCapabilities {
 	 //
 	 // @since 3.6.0
 	 //
-	boost::optional< std::pair< boost::optional<bool>, boost::optional<DocumentColorOptions> > >  colorProvider;
+	std::optional< std::pair< std::optional<bool>, std::optional<DocumentColorOptions> > >  colorProvider;
 
 
 	//
@@ -459,22 +459,22 @@ struct lsServerCapabilities {
 		 //
 		 // @since 3.10.0
 		 //
-	boost::optional <  std::pair< boost::optional<bool>, boost::optional<FoldingRangeOptions> >   > foldingRangeProvider;
+	std::optional <  std::pair< std::optional<bool>, std::optional<FoldingRangeOptions> >   > foldingRangeProvider;
 
 	// The server provides execute command support.
-	boost::optional < lsExecuteCommandOptions >executeCommandProvider;
+	std::optional < lsExecuteCommandOptions >executeCommandProvider;
 
 
 	//
 	 // Workspace specific server capabilities
 	 //
-	boost::optional< WorkspaceServerCapabilities > workspace;
+	std::optional< WorkspaceServerCapabilities > workspace;
 
 	//
 	 // Semantic highlighting server capabilities.
 	 //
 
-	 boost::optional<	 SemanticHighlightingServerCapabilities >semanticHighlighting;
+	 std::optional<	 SemanticHighlightingServerCapabilities >semanticHighlighting;
 
 	//
 	 // Server capability for calculating super- and subtype hierarchies.
@@ -486,31 +486,31 @@ struct lsServerCapabilities {
 	 // language feature</a> is not yet part of the official LSP specification.
 	 //
 
-	 boost::optional< std::pair< boost::optional<bool>,
-	boost::optional<StaticRegistrationOptions> > > typeHierarchyProvider;
+	 std::optional< std::pair< std::optional<bool>,
+	std::optional<StaticRegistrationOptions> > > typeHierarchyProvider;
 
 	//
 	 // The server provides Call Hierarchy support.
 	 //
 
-	 boost::optional< std::pair< boost::optional<bool>,
-	boost::optional<StaticRegistrationOptions> > > callHierarchyProvider;
+	 std::optional< std::pair< std::optional<bool>,
+	std::optional<StaticRegistrationOptions> > > callHierarchyProvider;
 
 	//
 	 // The server provides selection range support.
 	 //
 	 // Since 3.15.0
 	 //
-	 boost::optional< std::pair< boost::optional<bool>,
-	boost::optional<StaticRegistrationOptions> > > selectionRangeProvider;
+	 std::optional< std::pair< std::optional<bool>,
+	std::optional<StaticRegistrationOptions> > > selectionRangeProvider;
 
 	 //
 	  // The server provides linked editing range support.
 	  //
 	  // Since 3.16.0
 	  //
-	 boost::optional< std::pair< boost::optional<bool>,
-		 boost::optional<StaticRegistrationOptions> > > linkedEditingRangeProvider;
+	 std::optional< std::pair< std::optional<bool>,
+		 std::optional<StaticRegistrationOptions> > > linkedEditingRangeProvider;
 
 
 	 //
@@ -518,17 +518,17 @@ struct lsServerCapabilities {
 	  //
 	  // Since 3.16.0
 	  //
-	 boost::optional < SemanticTokensWithRegistrationOptions> semanticTokensProvider;
+	 std::optional < SemanticTokensWithRegistrationOptions> semanticTokensProvider;
 
 	 //
 	  // Whether server provides moniker support.
 	  //
 	  // Since 3.16.0
 	  //
-	 boost::optional< std::pair< boost::optional<bool>,
-		 boost::optional<StaticRegistrationOptions> > >  monikerProvider;
+	 std::optional< std::pair< std::optional<bool>,
+		 std::optional<StaticRegistrationOptions> > >  monikerProvider;
 
-	boost::optional<lsp::Any> experimental;
+	std::optional<lsp::Any> experimental;
 
 
 	MAKE_SWAP_METHOD(lsServerCapabilities,

--- a/include/LibLsp/lsp/general/lsTextDocumentClientCapabilities.h
+++ b/include/LibLsp/lsp/general/lsTextDocumentClientCapabilities.h
@@ -14,7 +14,7 @@
 
 struct  WorkDoneProgressOptions
 {
-	boost::optional<bool>workDoneProgress;
+	std::optional<bool>workDoneProgress;
 	MAKE_SWAP_METHOD(WorkDoneProgressOptions, workDoneProgress);
 };
 MAKE_REFLECT_STRUCT(WorkDoneProgressOptions, workDoneProgress);
@@ -24,7 +24,7 @@ struct lsCompletionOptions:WorkDoneProgressOptions
 {
   // The server provides support to resolve additional
   // information for a completion item.
-  boost::optional<bool>  resolveProvider = false;
+  std::optional<bool>  resolveProvider = false;
 
   //
    // Most tools trigger completion request automatically without explicitly requesting
@@ -37,14 +37,14 @@ struct lsCompletionOptions:WorkDoneProgressOptions
    // an identifier (for example `.` in JavaScript) list them in `triggerCharacters`.
    //
   // https://github.com/Microsoft/language-server-protocol/issues/138.
-  boost::optional< std::vector<std::string> > triggerCharacters ;
+  std::optional< std::vector<std::string> > triggerCharacters ;
 
   //
    // The list of all possible characters that commit a completion. This field can be used
    // if clients don't support individual commmit characters per completion item. See
    // `ClientCapabilities.textDocument.completion.completionItem.commitCharactersSupport`
    //
-  boost::optional< std::vector<std::string> > allCommitCharacters;
+  std::optional< std::vector<std::string> > allCommitCharacters;
 
   MAKE_SWAP_METHOD(lsCompletionOptions, workDoneProgress, resolveProvider, triggerCharacters, allCommitCharacters);
 };
@@ -102,16 +102,16 @@ MAKE_REFLECT_TYPE_PROXY(lsTextDocumentSyncKind)
 
 struct lsTextDocumentSyncOptions {
   // Open and close notifications are sent to the server.
-  boost::optional<bool>  openClose ;
+  std::optional<bool>  openClose ;
   // Change notificatins are sent to the server. See TextDocumentSyncKind.None,
   // TextDocumentSyncKind.Full and TextDocumentSyncKindIncremental.
-  boost::optional< lsTextDocumentSyncKind> change ;
+  std::optional< lsTextDocumentSyncKind> change ;
   // Will save notifications are sent to the server.
-  boost::optional<bool> willSave;
+  std::optional<bool> willSave;
   // Will save wait until requests are sent to the server.
-  boost::optional<bool> willSaveWaitUntil;
+  std::optional<bool> willSaveWaitUntil;
   // Save notifications are sent to the server.
-  boost::optional<lsSaveOptions> save;
+  std::optional<lsSaveOptions> save;
 
   MAKE_SWAP_METHOD(lsTextDocumentSyncOptions,
 	  openClose,
@@ -129,18 +129,18 @@ MAKE_REFLECT_STRUCT(lsTextDocumentSyncOptions,
 
 struct SynchronizationCapabilities {
 	// Whether text document synchronization supports dynamic registration.
-	boost::optional<bool> dynamicRegistration;
+	std::optional<bool> dynamicRegistration;
 
 	// The client supports sending will save notifications.
-	boost::optional<bool> willSave;
+	std::optional<bool> willSave;
 
 	// The client supports sending a will save request and
 	// waits for a response providing text edits which will
 	// be applied to the document before it is saved.
-	boost::optional<bool> willSaveWaitUntil;
+	std::optional<bool> willSaveWaitUntil;
 
 	// The client supports did save notifications.
-	boost::optional<bool> didSave;
+	std::optional<bool> didSave;
 
 	MAKE_SWAP_METHOD(SynchronizationCapabilities,
 		dynamicRegistration,
@@ -156,7 +156,7 @@ MAKE_REFLECT_STRUCT(SynchronizationCapabilities,
 
 struct CompletionItemKindCapabilities
 {
-	boost::optional<std::vector<lsCompletionItemKind> >valueSet;
+	std::optional<std::vector<lsCompletionItemKind> >valueSet;
 	MAKE_SWAP_METHOD(CompletionItemKindCapabilities, valueSet);
 };
 MAKE_REFLECT_STRUCT(CompletionItemKindCapabilities, valueSet);
@@ -168,26 +168,26 @@ struct CompletionItemCapabilities {
 	// and `${3:foo}`. `$0` defines the final tab stop, it defaults to
 	// the end of the snippet. Placeholders with equal identifiers are linked,
 	// that is typing in one will update others too.
-	boost::optional<bool> snippetSupport;
+	std::optional<bool> snippetSupport;
 
         // Client supports commit characters on a completion item.
 
-	boost::optional<bool> commitCharactersSupport;
+	std::optional<bool> commitCharactersSupport;
 
 
         // Client supports the following content formats for the documentation
         // property. The order describes the preferred format of the client.
 
-	boost::optional< std::vector<std::string> > documentationFormat;
+	std::optional< std::vector<std::string> > documentationFormat;
 
         // Client supports the deprecated property on a completion item.
 
-	boost::optional<bool> deprecatedSupport;
+	std::optional<bool> deprecatedSupport;
 
 	//
 	 // Client supports the preselect property on a completion item.
 	 //
-	boost::optional<bool> preselectSupport;
+	std::optional<bool> preselectSupport;
 
 	MAKE_SWAP_METHOD(CompletionItemCapabilities,
 		snippetSupport,
@@ -207,25 +207,25 @@ MAKE_REFLECT_STRUCT(CompletionItemCapabilities,
  //
 struct CompletionCapabilities {
 	// Whether completion supports dynamic registration.
-	boost::optional<bool> dynamicRegistration;
+	std::optional<bool> dynamicRegistration;
 
 
 
 	// The client supports the following `CompletionItem` specific
 	// capabilities.
-	boost::optional<CompletionItemCapabilities> completionItem;
+	std::optional<CompletionItemCapabilities> completionItem;
 
 	//
 	 // The client supports the following `CompletionItemKind` specific
 	 // capabilities.
 	 //
-	boost::optional<CompletionItemKindCapabilities> completionItemKind;
+	std::optional<CompletionItemKindCapabilities> completionItemKind;
 
 	//
 	 // The client supports sending additional context information for a
 	 // `textDocument/completion` request.
 	 //
-	boost::optional<bool> contextSupport;
+	std::optional<bool> contextSupport;
 
 
 	MAKE_SWAP_METHOD(CompletionCapabilities,
@@ -246,7 +246,7 @@ struct HoverCapabilities:public DynamicRegistrationCapabilities
  //
  // See {@link MarkupKind} for allowed values.
  //
-	boost::optional<std::vector<std::string>> contentFormat;
+	std::optional<std::vector<std::string>> contentFormat;
 
 	MAKE_SWAP_METHOD(HoverCapabilities, dynamicRegistration, contentFormat);
 };
@@ -262,7 +262,7 @@ struct	ParameterInformationCapabilities {
 	 //
 	 // Since 3.14.0
 	 //
-	boost::optional<bool> labelOffsetSupport;
+	std::optional<bool> labelOffsetSupport;
 
 	MAKE_SWAP_METHOD(ParameterInformationCapabilities, labelOffsetSupport);
 };
@@ -293,7 +293,7 @@ struct SignatureHelpCapabilities :public DynamicRegistrationCapabilities
 	 // The client supports the following `SignatureInformation`
 	 // specific properties.
 	 //
-	boost::optional< SignatureInformationCapabilities  > signatureInformation;
+	std::optional< SignatureInformationCapabilities  > signatureInformation;
 
 	MAKE_SWAP_METHOD(SignatureHelpCapabilities, dynamicRegistration, signatureInformation)
 };
@@ -303,12 +303,12 @@ struct DocumentSymbolCapabilities :public DynamicRegistrationCapabilities {
 	//
 	 // Specific capabilities for the `SymbolKind`.
 	 //
-	boost::optional<SymbolKindCapabilities>  symbolKind;
+	std::optional<SymbolKindCapabilities>  symbolKind;
 
 	//
 	 // The client support hierarchical document symbols.
 	 //
-	 boost::optional<bool> hierarchicalDocumentSymbolSupport;
+	 std::optional<bool> hierarchicalDocumentSymbolSupport;
 
 	 MAKE_SWAP_METHOD(DocumentSymbolCapabilities, dynamicRegistration, symbolKind, hierarchicalDocumentSymbolSupport)
 };
@@ -318,7 +318,7 @@ struct DeclarationCapabilities:public DynamicRegistrationCapabilities{
 	//
 	 // The client supports additional metadata in the form of declaration links.
 	 //
-	boost::optional<bool>linkSupport;
+	std::optional<bool>linkSupport;
 
 	MAKE_SWAP_METHOD(DeclarationCapabilities, dynamicRegistration, linkSupport);
 };
@@ -335,7 +335,7 @@ struct CodeActionKindCapabilities
 	 //
 	 // See {@link CodeActionKind} for allowed values.
 	 //
-	boost::optional< std::vector< std::string> >valueSet;
+	std::optional< std::vector< std::string> >valueSet;
 
 	MAKE_SWAP_METHOD(CodeActionKindCapabilities, valueSet)
 };
@@ -343,7 +343,7 @@ MAKE_REFLECT_STRUCT(CodeActionKindCapabilities,valueSet)
 
 struct CodeActionLiteralSupportCapabilities
 {
-	boost::optional<CodeActionKindCapabilities> codeActionKind;
+	std::optional<CodeActionKindCapabilities> codeActionKind;
 
 	MAKE_SWAP_METHOD(CodeActionLiteralSupportCapabilities, codeActionKind)
 };
@@ -354,7 +354,7 @@ struct CodeActionCapabilities:public DynamicRegistrationCapabilities{
  // The client support code action literals as a valid
  // response of the `textDocument/codeAction` request.
  //
-	boost::optional<CodeActionLiteralSupportCapabilities> codeActionLiteralSupport;
+	std::optional<CodeActionLiteralSupportCapabilities> codeActionLiteralSupport;
 
 	MAKE_SWAP_METHOD(CodeActionCapabilities, dynamicRegistration, codeActionLiteralSupport)
 };
@@ -365,7 +365,7 @@ struct RenameCapabilities :public DynamicRegistrationCapabilities {
  // The client support code action literals as a valid
  // response of the `textDocument/codeAction` request.
  //
-	boost::optional<bool> prepareSupport;
+	std::optional<bool> prepareSupport;
 
 	MAKE_SWAP_METHOD(RenameCapabilities, dynamicRegistration, prepareSupport)
 };
@@ -385,7 +385,7 @@ struct PublishDiagnosticsClientCapabilities :public DynamicRegistrationCapabilit
  * The client support code action literals as a valid
  * response of the `textDocument/codeAction` request.
  */
-	boost::optional<bool> relatedInformation;
+	std::optional<bool> relatedInformation;
 
 	/**
 	 * Client supports the tag property to provide meta data about a diagnostic.
@@ -398,7 +398,7 @@ struct PublishDiagnosticsClientCapabilities :public DynamicRegistrationCapabilit
 	 *
 	 * Since 3.15
 	 */
-	boost::optional < std::pair<boost::optional<bool>, boost::optional<DiagnosticsTagSupport> > >  tagSupport;
+	std::optional < std::pair<std::optional<bool>, std::optional<DiagnosticsTagSupport> > >  tagSupport;
 
 	/**
 	 * Whether the client interprets the version property of the
@@ -406,14 +406,14 @@ struct PublishDiagnosticsClientCapabilities :public DynamicRegistrationCapabilit
 	 *
 	 * Since 3.15.0
 	 */
-	boost::optional<bool> versionSupport;
+	std::optional<bool> versionSupport;
 
 	/**
  * Client supports a codeDescription property
  *
  * @since 3.16.0
  */
-	boost::optional<bool> codeDescriptionSupport ;
+	std::optional<bool> codeDescriptionSupport ;
 
 	/**
 	 * Whether code action supports the `data` property which is
@@ -422,7 +422,7 @@ struct PublishDiagnosticsClientCapabilities :public DynamicRegistrationCapabilit
 	 *
 	 * @since 3.16.0
 	 */
-	boost::optional<bool> dataSupport ;
+	std::optional<bool> dataSupport ;
 
 
 	MAKE_SWAP_METHOD(PublishDiagnosticsClientCapabilities, dynamicRegistration, relatedInformation, tagSupport,versionSupport,codeDescriptionSupport,dataSupport)
@@ -435,13 +435,13 @@ struct FoldingRangeCapabilities :public DynamicRegistrationCapabilities {
 	 // The maximum number of folding ranges that the client prefers to receive per document. The value serves as a
 	 // hint, servers are free to follow the limit.
 	 //
-	boost::optional<int> rangeLimit;
+	std::optional<int> rangeLimit;
 
 	//
 	 // If set, the client signals that it only supports folding complete lines. If set, client will
 	 // ignore specified `startCharacter` and `endCharacter` properties in a FoldingRange.
 	 //
-	boost::optional<bool> lineFoldingOnly;
+	std::optional<bool> lineFoldingOnly;
 	MAKE_SWAP_METHOD(FoldingRangeCapabilities, dynamicRegistration, rangeLimit, lineFoldingOnly)
 };
 MAKE_REFLECT_STRUCT(FoldingRangeCapabilities, dynamicRegistration, rangeLimit,lineFoldingOnly)
@@ -452,7 +452,7 @@ struct SemanticHighlightingCapabilities :public DynamicRegistrationCapabilities 
  // The client support code action literals as a valid
  // response of the `textDocument/codeAction` request.
  //
-	boost::optional<bool> semanticHighlighting;
+	std::optional<bool> semanticHighlighting;
 
 	MAKE_SWAP_METHOD(SemanticHighlightingCapabilities, dynamicRegistration, semanticHighlighting)
 };
@@ -478,13 +478,13 @@ struct SemanticTokensClientCapabilities :  public DynamicRegistrationCapabilitie
 		 // The client will send the `textDocument/semanticTokens/range` request
 		 // if the server provides a corresponding handler.
 		 //
-		boost::optional<std::pair< boost::optional<bool>,
-		boost::optional<SemanticTokensClientCapabilitiesRequestsFull>>>  range;
+		std::optional<std::pair< std::optional<bool>,
+		std::optional<SemanticTokensClientCapabilitiesRequestsFull>>>  range;
 		//
 		 // The client will send the `textDocument/semanticTokens/full` request
 		 // if the server provides a corresponding handler.
 		 //
-		boost::optional<std::pair< boost::optional<bool>, boost::optional<lsp::Any>>> full;
+		std::optional<std::pair< std::optional<bool>, std::optional<lsp::Any>>> full;
 		MAKE_SWAP_METHOD(lsRequests, range, full)
 	};
 
@@ -505,12 +505,12 @@ struct SemanticTokensClientCapabilities :  public DynamicRegistrationCapabilitie
 	//
 	 // Whether the client supports tokens that can overlap each other.
 	 //
-	boost::optional < bool >overlappingTokenSupport;
+	std::optional < bool >overlappingTokenSupport;
 
 	//
 	 // Whether the client supports tokens that can span multiple lines.
 	 //
-	boost::optional < bool > multilineTokenSupport;
+	std::optional < bool > multilineTokenSupport;
 
 	MAKE_SWAP_METHOD(SemanticTokensClientCapabilities, dynamicRegistration,requests, tokenTypes, tokenModifiers,
 		formats, overlappingTokenSupport, multilineTokenSupport)
@@ -527,37 +527,37 @@ struct lsTextDocumentClientCapabilities {
 
 
   // Capabilities specific to the `textDocument/completion`
-  boost::optional<CompletionCapabilities> completion;
+  std::optional<CompletionCapabilities> completion;
 
 
 
   // Capabilities specific to the `textDocument/hover`
-  boost::optional<HoverCapabilities> hover;
+  std::optional<HoverCapabilities> hover;
 
   // Capabilities specific to the `textDocument/signatureHelp`
-  boost::optional<SignatureHelpCapabilities> signatureHelp;
+  std::optional<SignatureHelpCapabilities> signatureHelp;
 
   // Capabilities specific to the `textDocument/references`
-  boost::optional<DynamicRegistrationCapabilities> references;
+  std::optional<DynamicRegistrationCapabilities> references;
 
 
 
 
 
   // Capabilities specific to the `textDocument/documentHighlight`
-  boost::optional<DynamicRegistrationCapabilities> documentHighlight;
+  std::optional<DynamicRegistrationCapabilities> documentHighlight;
 
   // Capabilities specific to the `textDocument/documentSymbol`
-  boost::optional<DocumentSymbolCapabilities> documentSymbol;
+  std::optional<DocumentSymbolCapabilities> documentSymbol;
 
   // Capabilities specific to the `textDocument/formatting`
-  boost::optional<DynamicRegistrationCapabilities> formatting;
+  std::optional<DynamicRegistrationCapabilities> formatting;
 
   // Capabilities specific to the `textDocument/rangeFormatting`
-  boost::optional<DynamicRegistrationCapabilities> rangeFormatting;
+  std::optional<DynamicRegistrationCapabilities> rangeFormatting;
 
   // Capabilities specific to the `textDocument/onTypeFormatting`
-  boost::optional<DynamicRegistrationCapabilities> onTypeFormatting;
+  std::optional<DynamicRegistrationCapabilities> onTypeFormatting;
 
 
   //
@@ -565,12 +565,12 @@ struct lsTextDocumentClientCapabilities {
  //
  // Since 3.14.0
  //
-  boost::optional< DeclarationCapabilities> declaration;
+  std::optional< DeclarationCapabilities> declaration;
 
 
   typedef  DeclarationCapabilities DefinitionCapabilities;
   // Capabilities specific to the `textDocument/definition`
-  boost::optional<DefinitionCapabilities> definition;
+  std::optional<DefinitionCapabilities> definition;
 
 
 
@@ -580,23 +580,23 @@ struct lsTextDocumentClientCapabilities {
 // Since 3.6.0
 //
   typedef  DeclarationCapabilities TypeDefinitionCapabilities;
-  boost::optional<TypeDefinitionCapabilities>  typeDefinition;
+  std::optional<TypeDefinitionCapabilities>  typeDefinition;
 
 
   typedef  DeclarationCapabilities ImplementationCapabilities;
   // Capabilities specific to the `textDocument/implementation`
-  boost::optional<ImplementationCapabilities> implementation;
+  std::optional<ImplementationCapabilities> implementation;
 
 
   // Capabilities specific to the `textDocument/codeAction`
-  boost::optional<CodeActionCapabilities> codeAction;
+  std::optional<CodeActionCapabilities> codeAction;
 
 
   // Capabilities specific to the `textDocument/codeLens`
-  boost::optional<DynamicRegistrationCapabilities> codeLens;
+  std::optional<DynamicRegistrationCapabilities> codeLens;
 
   // Capabilities specific to the `textDocument/documentLink`
-  boost::optional<DynamicRegistrationCapabilities> documentLink;
+  std::optional<DynamicRegistrationCapabilities> documentLink;
 
   //
  // Capabilities specific to the `textDocument/documentColor` and the
@@ -604,33 +604,33 @@ struct lsTextDocumentClientCapabilities {
  //
  // Since 3.6.0
  //
-  boost::optional<DynamicRegistrationCapabilities> colorProvider;
+  std::optional<DynamicRegistrationCapabilities> colorProvider;
 
   // Capabilities specific to the `textDocument/rename`
-  boost::optional<RenameCapabilities> rename;
+  std::optional<RenameCapabilities> rename;
 
 //
 // Capabilities specific to `textDocument/publishDiagnostics`.
 //
-  boost::optional<PublishDiagnosticsClientCapabilities> publishDiagnostics;
+  std::optional<PublishDiagnosticsClientCapabilities> publishDiagnostics;
 
   //
 // Capabilities specific to `textDocument/foldingRange` requests.
 //
 // Since 3.10.0
 //
-  boost::optional< FoldingRangeCapabilities > foldingRange;
+  std::optional< FoldingRangeCapabilities > foldingRange;
 
 
   //
    // Capabilities specific to {@code textDocument/semanticHighlighting}.
    //
-  boost::optional< SemanticHighlightingCapabilities >  semanticHighlightingCapabilities;
+  std::optional< SemanticHighlightingCapabilities >  semanticHighlightingCapabilities;
 
   //
    // Capabilities specific to {@code textDocument/typeHierarchy}.
    //
-  boost::optional< DynamicRegistrationCapabilities >  typeHierarchyCapabilities;
+  std::optional< DynamicRegistrationCapabilities >  typeHierarchyCapabilities;
 
 
 
@@ -638,35 +638,35 @@ struct lsTextDocumentClientCapabilities {
 // Capabilities specific to `textDocument/selectionRange` requests
 //
 
-  boost::optional< DynamicRegistrationCapabilities > selectionRange;
+  std::optional< DynamicRegistrationCapabilities > selectionRange;
 
   //
 	 // Capabilities specific to the `textDocument/linkedEditingRange` request.
 	 //
 	 // @since 3.16.0
 	 //
-  boost::optional< DynamicRegistrationCapabilities > linkedEditingRange;
+  std::optional< DynamicRegistrationCapabilities > linkedEditingRange;
 
   //
    // Capabilities specific to the various call hierarchy requests.
    //
    // @since 3.16.0
    //
-  boost::optional< DynamicRegistrationCapabilities > callHierarchy;
+  std::optional< DynamicRegistrationCapabilities > callHierarchy;
 
   //
    // Capabilities specific to the various semantic token requests.
    //
    // @since 3.16.0
    //
-  boost::optional< SemanticTokensClientCapabilities > semanticTokens;
+  std::optional< SemanticTokensClientCapabilities > semanticTokens;
 
   //
    // Capabilities specific to the `textDocument/moniker` request.
    //
    // @since 3.16.0
    //
-  boost::optional< DynamicRegistrationCapabilities >  moniker;
+  std::optional< DynamicRegistrationCapabilities >  moniker;
 
   MAKE_SWAP_METHOD(lsTextDocumentClientCapabilities,
 	  synchronization,

--- a/include/LibLsp/lsp/general/lsWorkspaceClientCapabilites.h
+++ b/include/LibLsp/lsp/general/lsWorkspaceClientCapabilites.h
@@ -26,7 +26,7 @@ struct lschangeAnnotationSupport
 	 * for instance all edits labelled with "Changes in Strings" would
 	 * be a tree node.
 	 */
-	boost::optional<bool> groupsOnLabel;
+	std::optional<bool> groupsOnLabel;
 	MAKE_SWAP_METHOD(lschangeAnnotationSupport, groupsOnLabel)
 };
 MAKE_REFLECT_STRUCT(lschangeAnnotationSupport, groupsOnLabel)
@@ -35,7 +35,7 @@ struct WorkspaceEditCapabilities {
 	/**
 	 * The client supports versioned document changes in `WorkspaceEdit`s
 	 */
-	boost::optional<bool>  documentChanges;
+	std::optional<bool>  documentChanges;
 
 	/**
 	 * The client supports resource changes
@@ -44,7 +44,7 @@ struct WorkspaceEditCapabilities {
 	 * @deprecated Since LSP introduces resource operations, use {link #resourceOperations}
 	 */
 
-	boost::optional<bool> resourceChanges;
+	std::optional<bool> resourceChanges;
 
 	/**
 	 * The resource operations the client supports. Clients should at least
@@ -52,7 +52,7 @@ struct WorkspaceEditCapabilities {
 	 *
 	 * @since 3.13.0
 	 */
-	boost::optional< std::vector<std::string> > resourceOperations;
+	std::optional< std::vector<std::string> > resourceOperations;
 
 	/**
 	 * The failure handling strategy of a client if applying the workspace edit
@@ -60,7 +60,7 @@ struct WorkspaceEditCapabilities {
 	 *
 	 * See {@link FailureHandlingKind} for allowed values.
 	 */
-	boost::optional<std::string > failureHandling;
+	std::optional<std::string > failureHandling;
 
 	/**
 	 * Whether the client normalizes line endings to the client specific
@@ -70,7 +70,7 @@ struct WorkspaceEditCapabilities {
 	 *
 	 * @since 3.16.0
 	 */
-	boost::optional<bool> normalizesLineEndings;;
+	std::optional<bool> normalizesLineEndings;;
 
 	/**
 	 * Whether the client in general supports change annotations on text edits,
@@ -78,7 +78,7 @@ struct WorkspaceEditCapabilities {
 	 *
 	 * @since 3.16.0
 	 */
-	boost::optional<lschangeAnnotationSupport> changeAnnotationSupport;
+	std::optional<lschangeAnnotationSupport> changeAnnotationSupport;
 	
 	MAKE_SWAP_METHOD(WorkspaceEditCapabilities, documentChanges, resourceChanges, resourceOperations, failureHandling, normalizesLineEndings, changeAnnotationSupport)
 
@@ -88,7 +88,7 @@ MAKE_REFLECT_STRUCT(WorkspaceEditCapabilities,documentChanges, resourceChanges, 
 
 struct DynamicRegistrationCapabilities {
 	// Did foo notification supports dynamic registration.
-	boost::optional<bool> dynamicRegistration;
+	std::optional<bool> dynamicRegistration;
 
 	MAKE_SWAP_METHOD(DynamicRegistrationCapabilities,
 		dynamicRegistration);
@@ -102,7 +102,7 @@ MAKE_REFLECT_STRUCT(DynamicRegistrationCapabilities,
 // Workspace specific client capabilities.
 struct SymbolKindCapabilities
 {
-	boost::optional< std::vector<lsSymbolKind> >  valueSet;
+	std::optional< std::vector<lsSymbolKind> >  valueSet;
 
 	MAKE_SWAP_METHOD(SymbolKindCapabilities, valueSet)
 
@@ -117,7 +117,7 @@ struct SymbolCapabilities :public DynamicRegistrationCapabilities {
 	/**
 	 * Specific capabilities for the `SymbolKind` in the `workspace/symbol` request.
 	 */
-	boost::optional<SymbolKindCapabilities>  symbolKind;
+	std::optional<SymbolKindCapabilities>  symbolKind;
 
 	MAKE_SWAP_METHOD(SymbolCapabilities,
 		symbolKind, dynamicRegistration)
@@ -132,37 +132,37 @@ struct lsFileOperations
  * Whether the client supports dynamic registration for file
  * requests/notifications.
  */
-	boost::optional<bool> dynamicRegistration ;
+	std::optional<bool> dynamicRegistration ;
 
 	/**
 	 * The client has support for sending didCreateFiles notifications.
 	 */
-	boost::optional<bool>didCreate ;
+	std::optional<bool>didCreate ;
 
 	/**
 	 * The client has support for sending willCreateFiles requests.
 	 */
-	boost::optional<bool>willCreate ;
+	std::optional<bool>willCreate ;
 
 	/**
 	 * The client has support for sending didRenameFiles notifications.
 	 */
-	boost::optional<bool>didRename ;
+	std::optional<bool>didRename ;
 
 	/**
 	 * The client has support for sending willRenameFiles requests.
 	 */
-	boost::optional<bool>willRename ;
+	std::optional<bool>willRename ;
 
 	/**
 	 * The client has support for sending didDeleteFiles notifications.
 	 */
-	boost::optional<bool>didDelete ;
+	std::optional<bool>didDelete ;
 
 	/**
 	 * The client has support for sending willDeleteFiles requests.
 	 */
-	boost::optional<bool> willDelete ;
+	std::optional<bool> willDelete ;
 	MAKE_SWAP_METHOD(lsFileOperations, dynamicRegistration, didCreate, willCreate,
 		didRename, willRename, didDelete, willDelete)
 };
@@ -171,28 +171,28 @@ MAKE_REFLECT_STRUCT(lsFileOperations, dynamicRegistration, didCreate, willCreate
 
 struct lsWorkspaceClientCapabilites {
   // The client supports applying batch edits to the workspace.
-  boost::optional<bool> applyEdit;
+  std::optional<bool> applyEdit;
 
  
 
   // Capabilities specific to `WorkspaceEdit`s
-  boost::optional<WorkspaceEditCapabilities> workspaceEdit;
+  std::optional<WorkspaceEditCapabilities> workspaceEdit;
 
 
 
   // Capabilities specific to the `workspace/didChangeConfiguration`
   // notification.
-  boost::optional<DynamicRegistrationCapabilities> didChangeConfiguration;
+  std::optional<DynamicRegistrationCapabilities> didChangeConfiguration;
 
   // Capabilities specific to the `workspace/didChangeWatchedFiles`
   // notification.
-  boost::optional<DynamicRegistrationCapabilities> didChangeWatchedFiles;
+  std::optional<DynamicRegistrationCapabilities> didChangeWatchedFiles;
 
   // Capabilities specific to the `workspace/symbol` request.
-  boost::optional<SymbolCapabilities> symbol;
+  std::optional<SymbolCapabilities> symbol;
 
   // Capabilities specific to the `workspace/executeCommand` request.
-  boost::optional<DynamicRegistrationCapabilities> executeCommand;
+  std::optional<DynamicRegistrationCapabilities> executeCommand;
 
 
   /**
@@ -200,14 +200,14 @@ struct lsWorkspaceClientCapabilites {
  *
  * Since 3.6.0
  */
-  boost::optional<bool> workspaceFolders;
+  std::optional<bool> workspaceFolders;
 
   /**
    * The client supports `workspace/configuration` requests.
    *
    * Since 3.6.0
    */
-  boost::optional<bool> configuration;
+  std::optional<bool> configuration;
 
 
   /**
@@ -216,7 +216,7 @@ struct lsWorkspaceClientCapabilites {
 		 *
 		 * @since 3.16.0
 		 */
-  boost::optional<DynamicRegistrationCapabilities> semanticTokens ;
+  std::optional<DynamicRegistrationCapabilities> semanticTokens ;
 
   /**
    * Capabilities specific to the code lens requests scoped to the
@@ -224,14 +224,14 @@ struct lsWorkspaceClientCapabilites {
    *
    * @since 3.16.0
    */
-  boost::optional<DynamicRegistrationCapabilities> codeLens ;
+  std::optional<DynamicRegistrationCapabilities> codeLens ;
 
   /**
    * The client has support for file requests/notifications.
    *
    * @since 3.16.0
    */
-  boost::optional<lsFileOperations> fileOperations;
+  std::optional<lsFileOperations> fileOperations;
 	
   MAKE_SWAP_METHOD(lsWorkspaceClientCapabilites,
 	  applyEdit,

--- a/include/LibLsp/lsp/general/progress.h
+++ b/include/LibLsp/lsp/general/progress.h
@@ -8,7 +8,7 @@
 //and partial result progress to support streaming of results.
 struct  ProgressParams
 {
-	std::pair<boost::optional<std::string> , boost::optional<int> > token;
+	std::pair<std::optional<std::string> , std::optional<int> > token;
 	lsp::Any value;
 	MAKE_SWAP_METHOD(ProgressParams, token, value)
 };

--- a/include/LibLsp/lsp/general/shutdown.h
+++ b/include/LibLsp/lsp/general/shutdown.h
@@ -11,5 +11,5 @@
  * that asks the server to exit.
  */
 
-DEFINE_REQUEST_RESPONSE_TYPE(td_shutdown, boost::optional<JsonNull>, boost::optional<lsp::Any>, "shutdown");
+DEFINE_REQUEST_RESPONSE_TYPE(td_shutdown, std::optional<JsonNull>, std::optional<lsp::Any>, "shutdown");
 

--- a/include/LibLsp/lsp/language/language.h
+++ b/include/LibLsp/lsp/language/language.h
@@ -89,7 +89,7 @@ struct ActionableNotification {
 	 *
 	 */
 
-	boost::optional<lsp::Any> data;
+	std::optional<lsp::Any> data;
 
 
 	/**

--- a/include/LibLsp/lsp/location_type.h
+++ b/include/LibLsp/lsp/location_type.h
@@ -35,7 +35,7 @@ struct LocationLink
 	 * Used as the underlined span for mouse interaction. Defaults to the word range at
 	 * the mouse position.
 	 */
-	boost::optional<lsRange>  originSelectionRange;
+	std::optional<lsRange>  originSelectionRange;
 
 	/**
 	 * The target resource identifier of this link.

--- a/include/LibLsp/lsp/lsAny.h
+++ b/include/LibLsp/lsp/lsAny.h
@@ -64,7 +64,7 @@ namespace lsp
 		template <typename  T>
 		bool GetForMapHelper(T& value);
 		bool GetForMapHelper(std::string& value);
-		bool GetForMapHelper(boost::optional<std::string>& value);
+		bool GetForMapHelper(std::optional<std::string>& value);
 	private:
 		std::unique_ptr<Reader> GetReader();
 		std::unique_ptr<Writer> GetWriter() const;

--- a/include/LibLsp/lsp/lsCodeAction.h
+++ b/include/LibLsp/lsp/lsCodeAction.h
@@ -24,24 +24,24 @@ struct CodeAction
 	 *
 	 * Used to filter code actions.
 	 */
-	boost::optional < std::string> kind;
+	std::optional < std::string> kind;
 
 	/**
 	 * The diagnostics that this code action resolves.
 	 */
-	boost::optional < std::vector<lsDiagnostic>> diagnostics;
+	std::optional < std::vector<lsDiagnostic>> diagnostics;
 
 	/**
 	 * The workspace edit this code action performs.
 	 */
-	boost::optional < lsWorkspaceEdit >edit;
+	std::optional < lsWorkspaceEdit >edit;
 
 	/**
 	 * A command this code action executes. If a code action
 	 * provides a edit and a command, first the edit is
 	 * executed and then the command.
 	 */
-	 boost::optional< lsCommandWithAny >  command;
+	 std::optional< lsCommandWithAny >  command;
 
 	 MAKE_SWAP_METHOD(CodeAction, title, kind, diagnostics, edit, command)
 };
@@ -50,7 +50,7 @@ struct TextDocumentCodeAction
 
 {
 
-	typedef  std::pair<boost::optional<lsCommandWithAny>, boost::optional<CodeAction> > Either;
+	typedef  std::pair<std::optional<lsCommandWithAny>, std::optional<CodeAction> > Either;
 
 };
 

--- a/include/LibLsp/lsp/lsCommand.h
+++ b/include/LibLsp/lsp/lsCommand.h
@@ -22,7 +22,7 @@ struct lsCommand {
 	// Arguments to run the command with.
 	// **NOTE** This must be serialized as an array. Use
 	// MAKE_REFLECT_STRUCT_WRITER_AS_ARRAY.
-	boost::optional<AnyArray> arguments;
+	std::optional<AnyArray> arguments;
 
 	void swap(lsCommand<AnyArray>& arg) noexcept
 	{

--- a/include/LibLsp/lsp/lsFormattingOptions.h
+++ b/include/LibLsp/lsp/lsFormattingOptions.h
@@ -4,9 +4,9 @@
 
 struct lsFormattingOptions {
 	struct KeyData {
-		boost::optional<bool> _boolean;
-		boost::optional<int32_t> _integer;
-		boost::optional<std::string> _string;
+		std::optional<bool> _boolean;
+		std::optional<int32_t> _integer;
+		std::optional<std::string> _string;
 	};
 
 	// Size of a tab in spaces.
@@ -19,22 +19,22 @@ struct lsFormattingOptions {
 		 *
 		 * @since 3.15.0
 		 */
-	boost::optional<bool> trimTrailingWhitespace;
+	std::optional<bool> trimTrailingWhitespace;
 
 	/**
 	 * Insert a newline character at the end of the file if one does not exist.
 	 *
 	 * @since 3.15.0
 	 */
-	boost::optional<bool> insertFinalNewline;
+	std::optional<bool> insertFinalNewline;
 
 	/**
 	 * Trim all newlines after the final newline at the end of the file.
 	 *
 	 * @since 3.15.0
 	 */
-	boost::optional<bool> trimFinalNewlines;
-	boost::optional<KeyData> key;
+	std::optional<bool> trimFinalNewlines;
+	std::optional<KeyData> key;
     MAKE_SWAP_METHOD(lsFormattingOptions, tabSize, insertSpaces, trimTrailingWhitespace, insertFinalNewline, trimFinalNewlines, key)
 };
 MAKE_REFLECT_STRUCT(lsFormattingOptions, tabSize, insertSpaces, trimTrailingWhitespace, insertFinalNewline, trimFinalNewlines, key);

--- a/include/LibLsp/lsp/lsMarkedString.h
+++ b/include/LibLsp/lsp/lsMarkedString.h
@@ -20,7 +20,7 @@
 // Note that markdown strings will be sanitized - that means html will be
 // escaped.
 struct lsMarkedString {
-	boost::optional<std::string> language;
+	std::optional<std::string> language;
 	std::string value;
 };
 

--- a/include/LibLsp/lsp/lsResponseError.h
+++ b/include/LibLsp/lsp/lsResponseError.h
@@ -108,7 +108,7 @@ struct lsResponseError {
 	 * A primitive or structured value that contains additional
 	 * information about the error. Can be omitted.
 	 */
-	boost::optional<lsp::Any> data;
+	std::optional<lsp::Any> data;
 	std::string ToString();
 	void Write(Writer& visitor);
 	

--- a/include/LibLsp/lsp/lsTextDocumentPositionParams.h
+++ b/include/LibLsp/lsp/lsTextDocumentPositionParams.h
@@ -18,7 +18,7 @@ struct lsTextDocumentPositionParams {
 	/**
 	 * Legacy property to support protocol version 1.0 requests.
 	 */
-	boost::optional<lsDocumentUri> uri;
+	std::optional<lsDocumentUri> uri;
 	
    MAKE_SWAP_METHOD(lsTextDocumentPositionParams, textDocument, position, uri);
 	

--- a/include/LibLsp/lsp/lsTextEdit.h
+++ b/include/LibLsp/lsp/lsTextEdit.h
@@ -27,13 +27,13 @@ struct lsChangeAnnotation
 	 * A flag which indicates that user confirmation is needed
 	 * before applying the change.
 	 */
-	boost::optional<bool>  needsConfirmation;
+	std::optional<bool>  needsConfirmation;
 
 	/**
 	 * A human-readable string which is rendered less prominent in
 	 * the user interface.
 	 */
-	boost::optional < std::string >  description;
+	std::optional < std::string >  description;
 	MAKE_REFLECT_STRUCT(lsChangeAnnotation, label, needsConfirmation, description)
 };
 MAKE_REFLECT_STRUCT(lsChangeAnnotation, label, needsConfirmation, description)
@@ -75,7 +75,7 @@ struct lsTextEdit {
 	/**
  * The actual annotation identifier.
  */
-	boost::optional<lsChangeAnnotationIdentifier>  annotationId;
+	std::optional<lsChangeAnnotationIdentifier>  annotationId;
 	
 
 		bool operator==(const lsTextEdit& that);

--- a/include/LibLsp/lsp/lsVersionedTextDocumentIdentifier.h
+++ b/include/LibLsp/lsp/lsVersionedTextDocumentIdentifier.h
@@ -10,7 +10,7 @@ struct lsVersionedTextDocumentIdentifier
 {
 	lsDocumentUri uri;
 	// The version number of this document.  number | null
-	boost::optional<int> version;
+	std::optional<int> version;
 
 	lsTextDocumentIdentifier AsTextDocumentIdentifier() const;
 

--- a/include/LibLsp/lsp/lsWorkspaceEdit.h
+++ b/include/LibLsp/lsp/lsWorkspaceEdit.h
@@ -33,10 +33,10 @@ struct lsWorkspaceEdit {
 	// version of a text document. Whether a client supports versioned document
 	// edits is expressed via `WorkspaceClientCapabilites.versionedWorkspaceEdit`.
 	//
-	boost::optional< std::map<std::string, std::vector<lsTextEdit> > >  changes;
-	typedef std::pair < boost::optional<lsTextDocumentEdit>, boost::optional<lsp::Any> > Either;
+	std::optional< std::map<std::string, std::vector<lsTextEdit> > >  changes;
+	typedef std::pair < std::optional<lsTextDocumentEdit>, std::optional<lsp::Any> > Either;
 
-	boost::optional <  std::vector< Either > > documentChanges;
+	std::optional <  std::vector< Either > > documentChanges;
 	/**
 	 * A map of change annotations that can be referenced in
 	 * `AnnotatedTextEdit`s or create, rename and delete file / folder
@@ -47,7 +47,7 @@ struct lsWorkspaceEdit {
 	 *
 	 * @since 3.16.0
 	 */
-	boost::optional< lsChangeAnnotations > changeAnnotations;
+	std::optional< lsChangeAnnotations > changeAnnotations;
 
 	MAKE_SWAP_METHOD(lsWorkspaceEdit, changes, documentChanges, changeAnnotations)
 };

--- a/include/LibLsp/lsp/lsp_completion.h
+++ b/include/LibLsp/lsp/lsp_completion.h
@@ -75,20 +75,20 @@ struct lsCompletionItem {
 
   // The kind of this completion item. Based of the kind
   // an icon is chosen by the editor.
-  boost::optional<lsCompletionItemKind>  kind ;
+  std::optional<lsCompletionItemKind>  kind ;
 
   // A human-readable string with additional information
   // about this item, like type or symbol information.
-  boost::optional < std::string > detail;
+  std::optional < std::string > detail;
 
   // A human-readable string that represents a doc-comment.
-  boost::optional< std::pair<boost::optional< std::string> , boost::optional<MarkupContent> > > documentation;
+  std::optional< std::pair<std::optional< std::string> , std::optional<MarkupContent> > > documentation;
 
 
   /**
    * Indicates if this item is deprecated.
    */
-  boost::optional< bool >deprecated;
+  std::optional< bool >deprecated;
 	
 
    /**
@@ -98,7 +98,7 @@ struct lsCompletionItem {
    * tool / client decides which item that is. The rule is that the *first
    * item of those that match best is selected.
    */
-  boost::optional< bool > preselect;
+  std::optional< bool > preselect;
 
 
   // Internal information to order candidates.
@@ -106,33 +106,33 @@ struct lsCompletionItem {
 
   // A string that shoud be used when comparing this item
   // with other items. When `falsy` the label is used.
-  boost::optional< std::string > sortText;
+  std::optional< std::string > sortText;
 
   // A string that should be used when filtering a set of
   // completion items. When `falsy` the label is used.
-  boost::optional<std::string> filterText;
+  std::optional<std::string> filterText;
 
   // A string that should be inserted a document when selecting
   // this completion. When `falsy` the label is used.
-  boost::optional<std::string> insertText;
+  std::optional<std::string> insertText;
 
   // The format of the insert text. The format applies to both the `insertText`
   // property and the `newText` property of a provided `textEdit`.
-  boost::optional< lsInsertTextFormat> insertTextFormat ;
+  std::optional< lsInsertTextFormat> insertTextFormat ;
 
   // An edit which is applied to a document when selecting this completion. When
   // an edit is provided the value of `insertText` is ignored.
   //
   // *Note:* The range of the edit must be a single line range and it must
   // contain the position at which completion has been requested.
-  boost::optional<lsTextEdit> textEdit;
+  std::optional<lsTextEdit> textEdit;
 
-  // An boost::optional array of additional text edits that are applied when
+  // An std::optional array of additional text edits that are applied when
   // selecting this completion. Edits must not overlap with the main edit
   // nor with themselves.
   // std::vector<TextEdit> additionalTextEdits;
 
-  // An boost::optional command that is executed *after* inserting this completion.
+  // An std::optional command that is executed *after* inserting this completion.
   // *Note* that additional modifications to the current document should be
   // described with the additionalTextEdits-property. Command command;
 
@@ -147,7 +147,7 @@ struct lsCompletionItem {
 
   std::string DisplayText();
   /**
- * An boost::optional array of additional text edits that are applied when
+ * An std::optional array of additional text edits that are applied when
  * selecting this completion. Edits must not overlap (including the same insert position)
  * with the main edit nor with themselves.
  *
@@ -155,26 +155,26 @@ struct lsCompletionItem {
  * (for example adding an import statement at the top of the file if the completion item will
  * insert an unqualified type).
  */
-  boost::optional<std::vector<lsTextEdit> >additionalTextEdits;
+  std::optional<std::vector<lsTextEdit> >additionalTextEdits;
 
   /**
-* An boost::optional set of characters that when pressed while this completion is active will accept it first and
+* An std::optional set of characters that when pressed while this completion is active will accept it first and
 * then type that character. *Note* that all commit characters should have `length=1` and that superfluous
 * characters will be ignored.
 */
-  boost::optional< std::vector<std::string> > commitCharacters;
+  std::optional< std::vector<std::string> > commitCharacters;
 
   /**
-* An boost::optional command that is executed *after* inserting this completion. *Note* that
+* An std::optional command that is executed *after* inserting this completion. *Note* that
 * additional modifications to the current document should be described with the
 * additionalTextEdits-property.
 */
-  boost::optional<lsCommandWithAny> command;
+  std::optional<lsCommandWithAny> command;
 
   /**
 * An data entry field that is preserved on a completion item between a completion and a completion resolve request.
 */
-  boost::optional<lsp::Any> data;
+  std::optional<lsp::Any> data;
   std::string ToString();
   MAKE_SWAP_METHOD(lsCompletionItem,
 	  label,

--- a/include/LibLsp/lsp/lsp_diagnostic.h
+++ b/include/LibLsp/lsp/lsp_diagnostic.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <optional>
 #include "lsRange.h"
 #include "lsTextEdit.h"
 #include "lsDocumentUri.h"
@@ -92,15 +93,15 @@ struct lsDiagnostic {
 
   // The diagnostic's severity. Can be omitted. If omitted it is up to the
   // client to interpret diagnostics as error, warning, info or hint.
-  boost::optional<lsDiagnosticSeverity> severity;
+  std::optional<lsDiagnosticSeverity> severity;
 
   // The diagnostic's code. Can be omitted.
-  boost::optional<  std::pair<boost::optional<std::string>, boost::optional<int>> >  code;
+  std::optional<  std::pair<std::optional<std::string>, std::optional<int>> >  code;
 
-  boost::optional<DiagnosticCodeDescription> codeDescription;
+  std::optional<DiagnosticCodeDescription> codeDescription;
   // A human-readable string describing the source of this
   // diagnostic, e.g. 'typescript' or 'super lint'.
-  boost::optional < std::string >source ;
+  std::optional < std::string >source ;
 
   // The diagnostic's message.
   std::string message;
@@ -113,7 +114,7 @@ struct lsDiagnostic {
    *
    * @since 3.15.0
    */
-  boost::optional<std::vector<DiagnosticTag>> tags;
+  std::optional<std::vector<DiagnosticTag>> tags;
 	
 
   /**
@@ -122,7 +123,7 @@ struct lsDiagnostic {
  *
  * Since 3.7.0
  */
-  boost::optional<std::vector<DiagnosticRelatedInformation>> relatedInformation;
+  std::optional<std::vector<DiagnosticRelatedInformation>> relatedInformation;
 
   /**
    * A data entry field that is preserved between a
@@ -131,7 +132,7 @@ struct lsDiagnostic {
    *
    * @since 3.16.0
    */
-  boost::optional<lsp::Any> data;
+  std::optional<lsp::Any> data;
   bool operator==(const lsDiagnostic& rhs) const;
   bool operator!=(const lsDiagnostic& rhs) const;
 

--- a/include/LibLsp/lsp/out_list.h
+++ b/include/LibLsp/lsp/out_list.h
@@ -15,7 +15,7 @@
 
 namespace LocationListEither{
 
-	typedef  std::pair< boost::optional<std::vector<lsLocation>> , boost::optional<std::vector<LocationLink> > > Either;
+	typedef  std::pair< std::optional<std::vector<lsLocation>> , std::optional<std::vector<LocationLink> > > Either;
 	
 };
 extern  void Reflect(Reader& visitor, LocationListEither::Either& value);

--- a/include/LibLsp/lsp/symbol.h
+++ b/include/LibLsp/lsp/symbol.h
@@ -66,7 +66,7 @@ struct lsDocumentHighlight {
   lsRange range;
 
   // The highlight kind, default is DocumentHighlightKind.Text.
-  boost::optional<lsDocumentHighlightKind>  kind ;
+  std::optional<lsDocumentHighlightKind>  kind ;
 
   MAKE_SWAP_METHOD(lsDocumentHighlight, range, kind)
 };
@@ -85,7 +85,7 @@ struct lsSymbolInformation {
   /**
 * Indicates if this symbol is deprecated.
 */
-  boost::optional<bool> deprecated;
+  std::optional<bool> deprecated;
   /**
    * The location of this symbol. The location's range is used by a tool
    * to reveal the location in the editor. If the symbol is selected in the
@@ -104,7 +104,7 @@ struct lsSymbolInformation {
  * if necessary). It can't be used to re-infer a hierarchy for the document
  * symbols.
  */
-  boost::optional<std::string>  containerName;
+  std::optional<std::string>  containerName;
 
 
   MAKE_SWAP_METHOD(lsSymbolInformation, name, kind, deprecated, location, containerName);
@@ -144,17 +144,17 @@ struct lsDocumentSymbol {
 	 * More detail for this symbol, e.g the signature of a function. If not provided the
 	 * name is used.
 	 */
-	boost::optional< std::string >  detail;
+	std::optional< std::string >  detail;
 
 	/**
 	 * Indicates if this symbol is deprecated.
 	 */
-	boost::optional< bool > deprecated;
+	std::optional< bool > deprecated;
 
 	/**
 	 * Children of this symbol, e.g. properties of a class.
 	 */
-	boost::optional < std::vector<lsDocumentSymbol> > children;
+	std::optional < std::vector<lsDocumentSymbol> > children;
 
 	//internal use
 	int flags=0;

--- a/include/LibLsp/lsp/textDocument/SemanticTokens.h
+++ b/include/LibLsp/lsp/textDocument/SemanticTokens.h
@@ -199,7 +199,7 @@ struct  SemanticTokens{
 	 * A server can then instead of computing all semantic tokens again simply
 	 * send a delta.
 	 */
-   boost::optional<std::string> resultId;
+   std::optional<std::string> resultId;
    MAKE_SWAP_METHOD(SemanticTokens, data, resultId)
 };
 MAKE_REFLECT_STRUCT(SemanticTokens, data, resultId)
@@ -245,12 +245,12 @@ MAKE_REFLECT_STRUCT(SemanticTokensEdit, startToken, deleteTokens, tokens)
 /// This models LSP SemanticTokensDelta | SemanticTokens, which is the result of
 /// textDocument/semanticTokens/full/delta.
 struct SemanticTokensOrDelta {
-	boost::optional<std::string >  resultId;
+	std::optional<std::string >  resultId;
 	/// Set if we computed edits relative to a previous set of tokens.
-	boost::optional< std::vector<SemanticTokensEdit> > edits;
+	std::optional< std::vector<SemanticTokensEdit> > edits;
 	/// Set if we computed a fresh set of tokens.
 	/// Set if we computed edits relative to a previous set of tokens.
-	boost::optional<std::vector<int32_t>> tokens; // encoded as integer array
+	std::optional<std::vector<int32_t>> tokens; // encoded as integer array
 	MAKE_REFLECT_STRUCT(SemanticTokensOrDelta, resultId, edits, tokens)
 };
 MAKE_REFLECT_STRUCT(SemanticTokensOrDelta, resultId, edits, tokens)
@@ -263,5 +263,5 @@ struct SemanticTokensLegend {
 };
 MAKE_REFLECT_STRUCT(SemanticTokensLegend, tokenTypes, tokenModifiers)
 
-DEFINE_REQUEST_RESPONSE_TYPE(td_semanticTokens_full, SemanticTokensParams,boost::optional<SemanticTokens >,"textDocument/semanticTokens/full")
-DEFINE_REQUEST_RESPONSE_TYPE(td_semanticTokens_full_delta, SemanticTokensDeltaParams, boost::optional<SemanticTokensOrDelta >, "textDocument/semanticTokens/full/delta")
+DEFINE_REQUEST_RESPONSE_TYPE(td_semanticTokens_full, SemanticTokensParams,std::optional<SemanticTokens >,"textDocument/semanticTokens/full")
+DEFINE_REQUEST_RESPONSE_TYPE(td_semanticTokens_full_delta, SemanticTokensDeltaParams, std::optional<SemanticTokensOrDelta >, "textDocument/semanticTokens/full/delta")

--- a/include/LibLsp/lsp/textDocument/callHierarchy.h
+++ b/include/LibLsp/lsp/textDocument/callHierarchy.h
@@ -35,10 +35,10 @@ struct CallHierarchyItem {
 	SymbolKind kind;
 
 	/// Tags for this item.
-	boost::optional<std::vector<SymbolTag>>  tags;
+	std::optional<std::vector<SymbolTag>>  tags;
 
 	/// More detaill for this item, e.g. the signature of a function.
-	boost::optional<std::string>  detail;
+	std::optional<std::string>  detail;
 
 	/// The resource identifier of this item.
 	lsDocumentUri uri;
@@ -60,7 +60,7 @@ struct CallHierarchyItem {
 	 * A data entry field that is preserved between a call hierarchy prepare and
 	 * incoming calls or outgoing calls requests.
 	 */
-	boost::optional<lsp::Any>  data;
+	std::optional<lsp::Any>  data;
 	MAKE_SWAP_METHOD(CallHierarchyItem, name, kind, tags, detail, uri, range, selectionRange, data)
 };
 MAKE_REFLECT_STRUCT(CallHierarchyItem, name, kind, tags, detail, uri, range, selectionRange, data)
@@ -112,10 +112,10 @@ MAKE_REFLECT_STRUCT(CallHierarchyOutgoingCall, to, fromRanges)
 
 
 DEFINE_REQUEST_RESPONSE_TYPE(td_prepareCallHierarchy, CallHierarchyPrepareParams,
-	boost::optional<std::vector<CallHierarchyItem>>, "textDocument/prepareCallHierarchy")
+	std::optional<std::vector<CallHierarchyItem>>, "textDocument/prepareCallHierarchy")
 
 DEFINE_REQUEST_RESPONSE_TYPE(td_incomingCalls, CallHierarchyIncomingCallsParams,
-	boost::optional<std::vector<CallHierarchyIncomingCall>>, "callHierarchy/incomingCalls")
+	std::optional<std::vector<CallHierarchyIncomingCall>>, "callHierarchy/incomingCalls")
 
 DEFINE_REQUEST_RESPONSE_TYPE(td_outgoingCalls, CallHierarchyOutgoingCallsParams,
-	boost::optional<std::vector<CallHierarchyOutgoingCall>>, "callHierarchy/CallHierarchyOutgoingCall")
+	std::optional<std::vector<CallHierarchyOutgoingCall>>, "callHierarchy/CallHierarchyOutgoingCall")

--- a/include/LibLsp/lsp/textDocument/code_lens.h
+++ b/include/LibLsp/lsp/textDocument/code_lens.h
@@ -21,10 +21,10 @@ struct lsCodeLens {
 	// The range in which this code lens is valid. Should only span a single line.
 	lsRange range;
 	// The command this code lens represents.
-	boost::optional<lsCommandWithAny> command;
+	std::optional<lsCommandWithAny> command;
 	// A data entry field that is preserved on a code lens item between
 	// a code lens and a code lens resolve request.
-	boost::optional< lsp::Any> data;
+	std::optional< lsp::Any> data;
 
 	MAKE_SWAP_METHOD(lsCodeLens, range, command, data)
 };

--- a/include/LibLsp/lsp/textDocument/completion.h
+++ b/include/LibLsp/lsp/textDocument/completion.h
@@ -30,7 +30,7 @@ struct lsCompletionContext {
 
   // The trigger character (a single character) that has trigger code complete.
   // Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
-  boost::optional<std::string> triggerCharacter;
+  std::optional<std::string> triggerCharacter;
 
   MAKE_SWAP_METHOD(lsCompletionContext, triggerKind, triggerCharacter);
 };
@@ -40,7 +40,7 @@ struct lsCompletionParams : lsTextDocumentPositionParams {
   // The completion context. This is only available it the client specifies to
   // send this using
   // `ClientCapabilities.textDocument.completion.contextSupport === true`
-  boost::optional<lsCompletionContext> context;
+  std::optional<lsCompletionContext> context;
 	
   MAKE_SWAP_METHOD(lsCompletionParams, textDocument, position, context);
 	
@@ -57,7 +57,7 @@ MAKE_REFLECT_STRUCT(lsCompletionParams, textDocument, position, context);
 
 namespace TextDocumentComplete{
 	
-	typedef  std::pair< boost::optional<std::vector<lsCompletionItem>>, boost::optional<CompletionList> > Either;
+	typedef  std::pair< std::optional<std::vector<lsCompletionItem>>, std::optional<CompletionList> > Either;
 	
 };
 extern  void Reflect(Reader& visitor, TextDocumentComplete::Either& value);

--- a/include/LibLsp/lsp/textDocument/didRenameFiles.h
+++ b/include/LibLsp/lsp/textDocument/didRenameFiles.h
@@ -38,7 +38,7 @@ public:
 MAKE_REFLECT_STRUCT(FileRenameParams, files);
 
 
-DEFINE_REQUEST_RESPONSE_TYPE(td_didRenameFiles, FileRenameParams, boost::optional<lsWorkspaceEdit>, "java/didRenameFiles");
+DEFINE_REQUEST_RESPONSE_TYPE(td_didRenameFiles, FileRenameParams, std::optional<lsWorkspaceEdit>, "java/didRenameFiles");
 
 
-DEFINE_REQUEST_RESPONSE_TYPE(td_willRenameFiles, FileRenameParams, boost::optional<lsWorkspaceEdit>, "java/willRenameFiles");
+DEFINE_REQUEST_RESPONSE_TYPE(td_willRenameFiles, FileRenameParams, std::optional<lsWorkspaceEdit>, "java/willRenameFiles");

--- a/include/LibLsp/lsp/textDocument/did_change.h
+++ b/include/LibLsp/lsp/textDocument/did_change.h
@@ -9,9 +9,9 @@
 #include "LibLsp/lsp/lsDocumentUri.h"
 struct lsTextDocumentContentChangeEvent {
 	// The range of the document that changed.
-	boost::optional<lsRange> range;
+	std::optional<lsRange> range;
 	// The length of the range that got replaced.
-	boost::optional<int> rangeLength;
+	std::optional<int> rangeLength;
 	// The new text of the range/document.
 	std::string text;
 
@@ -28,7 +28,7 @@ struct lsTextDocumentDidChangeParams {
 	 * Legacy property to support protocol version 1.0 requests.
 	 */
 	
-	boost::optional<lsDocumentUri>  uri;
+	std::optional<lsDocumentUri>  uri;
 	
 	void swap(lsTextDocumentDidChangeParams& arg) noexcept
 	{

--- a/include/LibLsp/lsp/textDocument/did_open.h
+++ b/include/LibLsp/lsp/textDocument/did_open.h
@@ -16,7 +16,7 @@ namespace TextDocumentDidOpen {
    /**
   * Legacy property to support protocol version 1.0 requests.
   */
-    boost::optional<std::string> text;
+    std::optional<std::string> text;
   	
    MAKE_SWAP_METHOD(TextDocumentDidOpen::Params, textDocument, text);
   

--- a/include/LibLsp/lsp/textDocument/did_save.h
+++ b/include/LibLsp/lsp/textDocument/did_save.h
@@ -13,7 +13,7 @@ namespace TextDocumentDidSave  {
 
     // Optional the content when saved. Depends on the includeText value
     // when the save notifcation was requested.
-    boost::optional<std::string>  text;
+    std::optional<std::string>  text;
 
 	MAKE_SWAP_METHOD(TextDocumentDidSave::Params, textDocument, text);
   };

--- a/include/LibLsp/lsp/textDocument/document_link.h
+++ b/include/LibLsp/lsp/textDocument/document_link.h
@@ -24,9 +24,9 @@ struct lsDocumentLink {
   // The range this link applies to.
   lsRange range;
   // The uri this link points to. If missing a resolve request is sent later.
-  boost::optional<lsDocumentUri> target;
+  std::optional<lsDocumentUri> target;
 
-  boost::optional<lsp::Any> data;
+  std::optional<lsp::Any> data;
 	
   MAKE_SWAP_METHOD(lsDocumentLink, range, target, data)
 	

--- a/include/LibLsp/lsp/textDocument/document_symbol.h
+++ b/include/LibLsp/lsp/textDocument/document_symbol.h
@@ -18,7 +18,7 @@ MAKE_REFLECT_STRUCT(lsDocumentSymbolParams, textDocument);
 
 
 struct  TextDocumentDocumentSymbol{
-	typedef  std::pair< boost::optional<lsSymbolInformation>  , boost::optional<lsDocumentSymbol> > Either;
+	typedef  std::pair< std::optional<lsSymbolInformation>  , std::optional<lsDocumentSymbol> > Either;
 };
 void Reflect(Reader& visitor, TextDocumentDocumentSymbol::Either& value);
 

--- a/include/LibLsp/lsp/textDocument/hover.h
+++ b/include/LibLsp/lsp/textDocument/hover.h
@@ -16,8 +16,8 @@
 
 namespace TextDocumentHover
 {
-	typedef  boost::optional< std::vector< std::pair<boost::optional<std::string>, boost::optional<lsMarkedString>> > > Left;
-	typedef   std::pair< Left, boost::optional<MarkupContent> >  Either;
+	typedef  std::optional< std::vector< std::pair<std::optional<std::string>, std::optional<lsMarkedString>> > > Left;
+	typedef   std::pair< Left, std::optional<MarkupContent> >  Either;
 	struct Result {
 		/**
 		 * The hover's content as markdown
@@ -25,16 +25,16 @@ namespace TextDocumentHover
 		Either  contents;
 		
 		/**
-		 * An boost::optional range
+		 * An std::optional range
 		 */
-		boost::optional<lsRange> range;
+		std::optional<lsRange> range;
 
 		MAKE_SWAP_METHOD(Result, contents, range)
 	};
 }
 MAKE_REFLECT_STRUCT(TextDocumentHover::Result, contents, range);
 
-extern  void Reflect(Reader& visitor, std::pair<boost::optional<std::string>, boost::optional<lsMarkedString>>& value);
+extern  void Reflect(Reader& visitor, std::pair<std::optional<std::string>, std::optional<lsMarkedString>>& value);
 extern  void Reflect(Reader& visitor, TextDocumentHover::Either& value);
 
 

--- a/include/LibLsp/lsp/textDocument/linkedEditingRange.h
+++ b/include/LibLsp/lsp/textDocument/linkedEditingRange.h
@@ -38,7 +38,7 @@ struct LinkedEditingRanges
 	 * pattern will be used.
 	 */
  
-	boost::optional<std::string> wordPattern;
+	std::optional<std::string> wordPattern;
 	MAKE_SWAP_METHOD(LinkedEditingRanges,
 		ranges,
 		wordPattern)
@@ -48,4 +48,4 @@ MAKE_REFLECT_STRUCT(LinkedEditingRanges,
 	ranges,
 	wordPattern)
 DEFINE_REQUEST_RESPONSE_TYPE(td_linkedEditingRange, LinkedEditingRangeParams,
-	boost::optional<std::vector<LinkedEditingRanges >>,"textDocument/linkedEditingRange")
+	std::optional<std::vector<LinkedEditingRanges >>,"textDocument/linkedEditingRange")

--- a/include/LibLsp/lsp/textDocument/prepareRename.h
+++ b/include/LibLsp/lsp/textDocument/prepareRename.h
@@ -32,7 +32,7 @@ MAKE_REFLECT_STRUCT(PrepareRenameResult,range,placeholder)
 
 
 
-typedef  std::pair< boost::optional< lsRange>, boost::optional<PrepareRenameResult>> TextDocumentPrepareRenameResult;
+typedef  std::pair< std::optional< lsRange>, std::optional<PrepareRenameResult>> TextDocumentPrepareRenameResult;
 extern void  Reflect(Reader& visitor, TextDocumentPrepareRenameResult& value);
 
 

--- a/include/LibLsp/lsp/textDocument/references.h
+++ b/include/LibLsp/lsp/textDocument/references.h
@@ -11,7 +11,7 @@ namespace  TextDocumentReferences {
 
   struct lsReferenceContext {
     // Include the declaration of the current symbol.
-    boost::optional<bool>  includeDeclaration;
+    std::optional<bool>  includeDeclaration;
    MAKE_REFLECT_STRUCT(lsReferenceContext,
 	   includeDeclaration)
   };

--- a/include/LibLsp/lsp/textDocument/resolveTypeHierarchy.h
+++ b/include/LibLsp/lsp/textDocument/resolveTypeHierarchy.h
@@ -18,7 +18,7 @@ struct ResolveTypeHierarchyItemParams {
 	/**
 	 * The number of hierarchy levels to resolve. {@code 0} indicates no hierarchy level.
 	 */
-	boost::optional<int>  resolve;
+	std::optional<int>  resolve;
 
 	/**
 	 * The direction of the type hierarchy resolution.

--- a/include/LibLsp/lsp/textDocument/selectionRange.h
+++ b/include/LibLsp/lsp/textDocument/selectionRange.h
@@ -35,11 +35,11 @@ struct SelectionRange {
 	/**
 	 * The parent selection range containing this range. Therefore `parent.range` must contain `this.range`.
 	 */
-	boost::optional<SelectionRange*> parent;
+	std::optional<SelectionRange*> parent;
 	MAKE_SWAP_METHOD(SelectionRange, range, parent)
 };
 
-extern  void Reflect(Reader& visitor, boost::optional<SelectionRange*>& value);
+extern  void Reflect(Reader& visitor, std::optional<SelectionRange*>& value);
 extern void Reflect(Writer& visitor, SelectionRange* value);
 
 MAKE_REFLECT_STRUCT(SelectionRange,range,parent)

--- a/include/LibLsp/lsp/textDocument/signature_help.h
+++ b/include/LibLsp/lsp/textDocument/signature_help.h
@@ -7,7 +7,7 @@
 #include "LibLsp/lsp/lsTextDocumentPositionParams.h"
 
 extern  void Reflect(Reader& visitor, 
-	std::pair<boost::optional<std::string>, boost::optional<MarkupContent>>& value);
+	std::pair<std::optional<std::string>, std::optional<MarkupContent>>& value);
 
 
 
@@ -20,7 +20,7 @@ struct lsParameterInformation {
 
   // The human-readable doc-comment of this parameter. Will be shown
   // in the UI but can be omitted.
-  boost::optional< std::pair<  boost::optional<std::string>  , boost::optional <MarkupContent>  > > documentation;
+  std::optional< std::pair<  std::optional<std::string>  , std::optional <MarkupContent>  > > documentation;
 
   MAKE_SWAP_METHOD(lsParameterInformation, label, documentation)
 };
@@ -36,7 +36,7 @@ struct lsSignatureInformation {
 
   // The human-readable doc-comment of this signature. Will be shown
   // in the UI but can be omitted.
-  boost::optional< std::pair<  boost::optional<std::string>, boost::optional <MarkupContent>  > > documentation;
+  std::optional< std::pair<  std::optional<std::string>, std::optional <MarkupContent>  > > documentation;
 
   // The parameters of this signature.
   std::vector<lsParameterInformation> parameters;
@@ -59,7 +59,7 @@ struct lsSignatureHelp {
   // rely on a default value.
   // In future version of the protocol this property might become
   // mandantory to better express this.
-  boost::optional<int> activeSignature;
+  std::optional<int> activeSignature;
 
   // The active parameter of the active signature. If omitted or the value
   // lies outside the range of `signatures[activeSignature].parameters`
@@ -68,7 +68,7 @@ struct lsSignatureHelp {
   // In future version of the protocol this property might become
   // mandantory to better express the active parameter if the
   // active signature does have any.
-  boost::optional<int> activeParameter;
+  std::optional<int> activeParameter;
 
 
   MAKE_SWAP_METHOD(lsSignatureHelp,

--- a/include/LibLsp/lsp/textDocument/typeHierarchy.h
+++ b/include/LibLsp/lsp/textDocument/typeHierarchy.h
@@ -42,8 +42,8 @@ void Reflect(Writer& writer, TypeHierarchyDirection& value);
 
 struct TypeHierarchyParams :public lsTextDocumentPositionParams
 {
-	boost::optional<int>  resolve;
-	boost::optional<TypeHierarchyDirection> direction ;
+	std::optional<int>  resolve;
+	std::optional<TypeHierarchyDirection> direction ;
 	
 	MAKE_SWAP_METHOD(TypeHierarchyParams, textDocument, position, resolve, direction)
 };
@@ -67,7 +67,7 @@ struct  TypeHierarchyItem {
 	/**
 	 * Optional detail for the hierarchy item. It can be, for instance, the signature of a function or method.
 	 */
-	boost::optional<std::string>
+	std::optional<std::string>
 	 detail;
 
 	/**
@@ -80,7 +80,7 @@ struct  TypeHierarchyItem {
 	 * {@code true} if the hierarchy item is deprecated. Otherwise, {@code false}. It is {@code false} by default.
 	 */
 	
-	boost::optional<bool> deprecated;
+	std::optional<bool> deprecated;
 
 	/**
 	 * The URI of the text document where this type hierarchy item belongs to.
@@ -111,18 +111,18 @@ struct  TypeHierarchyItem {
 	 * If this type hierarchy item is resolved, it contains the direct parents. Could be empty if the item does not have any
 	 * direct parents. If not defined, the parents have not been resolved yet.
 	 */
-	boost::optional< std::vector<TypeHierarchyItem> >  parents;
+	std::optional< std::vector<TypeHierarchyItem> >  parents;
 
 	/**
 	 * If this type hierarchy item is resolved, it contains the direct children of the current item.
 	 * Could be empty if the item does not have any descendants. If not defined, the children have not been resolved.
 	 */
-	boost::optional< std::vector<TypeHierarchyItem> >  children;
+	std::optional< std::vector<TypeHierarchyItem> >  children;
 
 	/**
- * An boost::optional data field can be used to identify a type hierarchy item in a resolve request.
+ * An std::optional data field can be used to identify a type hierarchy item in a resolve request.
  */
-	boost::optional<lsp::Any> data;
+	std::optional<lsp::Any> data;
 
 	MAKE_SWAP_METHOD(TypeHierarchyItem, name, detail, kind, deprecated, uri, range, selectionRange, parents, children, data)
 };

--- a/include/LibLsp/lsp/textDocument/willSave.h
+++ b/include/LibLsp/lsp/textDocument/willSave.h
@@ -40,7 +40,7 @@ namespace WillSaveTextDocumentParams {
    * A reason why a text document is saved.
    */
 
-	  boost::optional<TextDocumentSaveReason>  reason;
+	  std::optional<TextDocumentSaveReason>  reason;
 
 		MAKE_SWAP_METHOD(Params, textDocument, reason);
   };

--- a/include/LibLsp/lsp/utils.h
+++ b/include/LibLsp/lsp/utils.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <boost/optional/optional.hpp>
+#include <optional>
 #include <LibLsp/lsp/AbsolutePath.h>
 
 #include "lsPosition.h"
@@ -80,7 +80,7 @@ std::string EscapeFileName(std::string path);
 
 // FIXME: Move ReadContent into ICacheManager?
 bool FileExists(const std::string& filename);
-boost::optional<std::string> ReadContent(const AbsolutePath& filename);
+std::optional<std::string> ReadContent(const AbsolutePath& filename);
 std::vector<std::string> ReadLinesWithEnding(const AbsolutePath& filename);
 
 bool WriteToFile(const std::string& filename, const std::string& content);

--- a/include/LibLsp/lsp/workspace/applyEdit.h
+++ b/include/LibLsp/lsp/workspace/applyEdit.h
@@ -33,7 +33,7 @@ MAKE_REFLECT_STRUCT(ApplyWorkspaceEditParams, edit, label);
 struct  ApplyWorkspaceEditResponse
 {
 	bool applied;
-	boost::optional<std::string> failureReason;
+	std::optional<std::string> failureReason;
 	MAKE_SWAP_METHOD(ApplyWorkspaceEditResponse, applied, failureReason)
 };
 MAKE_REFLECT_STRUCT(ApplyWorkspaceEditResponse, applied, failureReason);

--- a/include/LibLsp/lsp/workspace/workspaceFolders.h
+++ b/include/LibLsp/lsp/workspace/workspaceFolders.h
@@ -30,5 +30,5 @@ MAKE_REFLECT_STRUCT(WorkspaceFolder, uri, name);
  *         the workspace folders otherwise.
  */
 DEFINE_REQUEST_RESPONSE_TYPE(WorkspaceFolders, 
-	boost::optional<JsonNull>, boost::optional<std::vector< WorkspaceFolder>>, "workspace/workspaceFolders");
+	std::optional<JsonNull>, std::optional<std::vector< WorkspaceFolder>>, "workspace/workspaceFolders");
 

--- a/src/jsonrpc/RemoteEndPoint.cpp
+++ b/src/jsonrpc/RemoteEndPoint.cpp
@@ -15,6 +15,7 @@
 #include "LibLsp/JsonRpc/ScopeExit.h"
 #include "LibLsp/JsonRpc/stream.h"
 #include <atomic>
+#include <optional>
 #include <boost/asio/thread_pool.hpp>
 #include <boost/asio/post.hpp>
 
@@ -103,7 +104,7 @@ namespace lsp {
 /// (If the context is within multiple nested tasks, true if any are cancelled).
 /// Always zero if there is no active cancelable task.
 /// This isn't free (context lookup) - don't call it in a tight loop.
-	boost::optional<CancelMonitor> getCancelledMonitor(const lsRequestId& id, const Context& ctx = Context::current()){
+	std::optional<CancelMonitor> getCancelledMonitor(const lsRequestId& id, const Context& ctx = Context::current()){
 		for (const CancelState* state = ctx.get(g_stateKey); state != nullptr;
 			state = state->parent)
 		{

--- a/src/lsp/initialize.cpp
+++ b/src/lsp/initialize.cpp
@@ -32,7 +32,7 @@ void Reflect(Writer& writer, lsInitializeParams::lsTrace& value)
 		break;
 	}
 }
- void Reflect(Reader& visitor, std::pair<boost::optional<lsTextDocumentSyncKind>, boost::optional<lsTextDocumentSyncOptions> >& value)
+ void Reflect(Reader& visitor, std::pair<std::optional<lsTextDocumentSyncKind>, std::optional<lsTextDocumentSyncOptions> >& value)
 {
 	if(((JsonReader&)visitor).m_->IsObject())
 	{

--- a/src/lsp/lsp.cpp
+++ b/src/lsp/lsp.cpp
@@ -397,7 +397,7 @@ bool lsp::Any::GetForMapHelper(std::string& value)
 	return Get(value);
 }
 
-bool lsp::Any::GetForMapHelper(boost::optional<std::string>& value)
+bool lsp::Any::GetForMapHelper(std::optional<std::string>& value)
 {
 	return Get(value);
 }
@@ -558,7 +558,7 @@ lsRenameFile::lsRenameFile()
 }
 
 
-void Reflect(Reader& visitor, boost::optional< SelectionRange* >& value)
+void Reflect(Reader& visitor, std::optional< SelectionRange* >& value)
 {
 	if (visitor.IsNull()) {
 		visitor.GetNull();

--- a/src/lsp/textDocument.cpp
+++ b/src/lsp/textDocument.cpp
@@ -231,7 +231,7 @@ void Reflect(Reader& visitor, TextDocumentDocumentSymbol::Either& value)
 	}
 }
 
-void Reflect(Reader& visitor, std::pair<boost::optional<std::string>, boost::optional<lsMarkedString>>& value)
+void Reflect(Reader& visitor, std::pair<std::optional<std::string>, std::optional<lsMarkedString>>& value)
 {
 
 	if (!visitor.IsString())
@@ -244,7 +244,7 @@ void Reflect(Reader& visitor, std::pair<boost::optional<std::string>, boost::opt
 	}
 }
 
-void Reflect(Reader& visitor, std::pair<boost::optional<std::string>, boost::optional<MarkupContent>>& value)
+void Reflect(Reader& visitor, std::pair<std::optional<std::string>, std::optional<MarkupContent>>& value)
 {
 	if (!visitor.IsString())
 	{

--- a/src/lsp/utils.cpp
+++ b/src/lsp/utils.cpp
@@ -191,7 +191,7 @@ bool FileExists(const std::string& filename) {
   return cache.is_open();
 }
 
-boost::optional<std::string> ReadContent(const AbsolutePath& filename) {
+std::optional<std::string> ReadContent(const AbsolutePath& filename) {
 
   std::ifstream cache;
   cache.open(filename.path);


### PR DESCRIPTION
This fixes some compilation errors with boost 1.66, present on some distros like
centOS 8. Moving to the std implementation also lessens the dependency on boost.

The minimum std version has been bumped to c++17, as it is needed for `std::optional` support.