### PR TITLE
Add argument to disable the build of WebSocketServer.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ option_if_not_defined(USE_SYSTEM_RAPIDJSON "Use system RapidJSON instead of the 
 option_if_not_defined(LSPCPP_WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
 option_if_not_defined(LSPCPP_BUILD_EXAMPLES "Build example applications" OFF)
 option_if_not_defined(LSPCPP_BUILD_FUZZER "Build fuzzer" OFF)
+option_if_not_defined(LSPCPP_BUILD_WEBSOCKETS "Build websocket server" ON)
 option_if_not_defined(LSPCPP_ASAN "Build lsp with address sanitizer" OFF)
 option_if_not_defined(LSPCPP_MSAN "Build lsp with memory sanitizer" OFF)
 option_if_not_defined(LSPCPP_TSAN "Build lsp with thread sanitizer" OFF)
@@ -241,7 +242,7 @@ foreach(include_dir  ${LSPCPP_THIRD_PARTY_DIR_LIST})
 endforeach()
 
 ### Sources
-set(LSPCPP_LIST
+set(JSONRPC_LIST
         src/jsonrpc/Context.cpp
         src/jsonrpc/Endpoint.cpp
         src/jsonrpc/GCThreadContext.cpp
@@ -252,8 +253,8 @@ set(LSPCPP_LIST
         src/jsonrpc/StreamMessageProducer.cpp
         src/jsonrpc/TcpServer.cpp
         src/jsonrpc/threaded_queue.cpp
-        src/jsonrpc/WebSocketServer.cpp
-
+)
+set(LSPCPP_LIST
         src/lsp/initialize.cpp
         src/lsp/lsp.cpp
         src/lsp/lsp_diagnostic.cpp
@@ -265,7 +266,15 @@ set(LSPCPP_LIST
         src/lsp/working_files.cpp
         )
 
+if(LSPCPP_BUILD_WEBSOCKETS)
+    set(JSONRPC_LIST
+        ${JSONRPC_LIST}
+        src/jsonrpc/WebSocketServer.cpp
+    )
+endif()
+
 target_sources(lspcpp PRIVATE
+        ${JSONRPC_LIST}
         ${LSPCPP_LIST})
 
 ### Compile options


### PR DESCRIPTION
Boost 1.66 does not have the necessary header files for tcp_stream.
If websocket support is not needed, lspcpp can be built successfully without WebSocketServer by setting `LSPCPP_BUILD_WEBSOCKETS` to `OFF`.