### PR TITLE
fix textDocument/documentLink

### DIFF
--- a/include/LibLsp/lsp/textDocument/document_link.h
+++ b/include/LibLsp/lsp/textDocument/document_link.h
@@ -34,11 +34,11 @@ struct lsDocumentLink {
 MAKE_REFLECT_STRUCT(lsDocumentLink, range, target,data);
 
 
-DEFINE_REQUEST_RESPONSE_TYPE(td_links, TextDocumentDocumentLink::Params, lsDocumentLink, "textDocument/documentLink");
+DEFINE_REQUEST_RESPONSE_TYPE(td_links, TextDocumentDocumentLink::Params, std::vector<lsDocumentLink>, "textDocument/documentLink");
 
 
 /**
  * The document link resolve request is sent from the client to the server to resolve the target of a given document link.
  */
-DEFINE_REQUEST_RESPONSE_TYPE(td_linkResolve, std::vector<lsDocumentLink>, lsDocumentLink, "documentLink/resolve");
+DEFINE_REQUEST_RESPONSE_TYPE(td_linkResolve, lsDocumentLink, lsDocumentLink, "documentLink/resolve");
 


### PR DESCRIPTION
`textDocument/documentLink` should return a vector of `lsDocumentLink`