### PR TITLE
remove reflect func proto

### DIFF
--- a/include/LibLsp/lsp/textDocument/signature_help.h
+++ b/include/LibLsp/lsp/textDocument/signature_help.h
@@ -6,11 +6,6 @@
 #include "LibLsp/lsp/lsMarkedString.h"
 #include "LibLsp/lsp/lsTextDocumentPositionParams.h"
 
-extern  void Reflect(Reader& visitor,
-        std::pair<optional<std::string>, optional<MarkupContent>>& value);
-
-
-
 // Represents a parameter of a callable-signature. A parameter can
 // have a label and a doc-comment.
 struct lsParameterInformation {


### PR DESCRIPTION
this reflect function gives the following link time errors, the application compiles and link fine without it

```
Main.cpp.obj : error LNK2019: unresolved external symbol "void __cdecl Reflect(class Reader &,struct std::pair<class std::optional<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > >,class std::optional<struct MarkupContent> > &)" (?Reflect@@YAXAEAVReader@@AEAU?$pair@V?$optional@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@std@@V?$optional@UMarkupContent@@@2@@std@@@Z) referenced in function "void __cdecl Reflect<struct std::pair<class std::optional<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > >,class std::optional<struct MarkupContent> > >(class Reader &,class std::optional<struct std::pair<class std::optional<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > >,class std::optional<struct MarkupContent> > > &)" (??$Reflect@U?$pair@V?$optional@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@std@@V?$optional@UMarkupContent@@@2@@std@@@@YAXAEAVReader@@AEAV?$optional@U?$pair@V?$optional@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@std@@V?$optional@UMarkupContent@@@2@@std@@@std@@@Z)
  Hint on symbols that are defined and could potentially match:
    "void __cdecl Reflect(class Reader &,unsigned char &)" (?Reflect@@YAXAEAVReader@@AEAE@Z)
    "void __cdecl Reflect(class Reader &,short &)" (?Reflect@@YAXAEAVReader@@AEAF@Z)
    "void __cdecl Reflect(class Reader &,unsigned short &)" (?Reflect@@YAXAEAVReader@@AEAG@Z)
```