### PR TITLE
fix use-after-free bug on d_ptr

### DIFF
--- a/src/jsonrpc/RemoteEndPoint.cpp
+++ b/src/jsonrpc/RemoteEndPoint.cpp
@@ -370,8 +370,13 @@ RemoteEndPoint::RemoteEndPoint(
 
 RemoteEndPoint::~RemoteEndPoint()
 {
-    delete d_ptr;
     d_ptr->quit.store(true, std::memory_order_relaxed);
+    if (this->message_producer_thread_ && this->message_producer_thread_->joinable())
+    {
+        this->message_producer_thread_->join();
+    }
+    delete d_ptr;
+    d_ptr = nullptr;
 }
 
 bool RemoteEndPoint::dispatch(std::string const& content)
@@ -654,11 +659,6 @@ void RemoteEndPoint::startProcessingMessages(std::shared_ptr<lsp::istream> r, st
 
 void RemoteEndPoint::stop()
 {
-    if (message_producer_thread_ && message_producer_thread_->joinable())
-    {
-        message_producer_thread_->detach();
-        message_producer_thread_ = nullptr;
-    }
     d_ptr->clear();
 }
 


### PR DESCRIPTION
This fixes two use-after-free bugs on the d_ptr member variable. The thread referenced by message_producer_thread_ makes regularly calls to d_ptr and therefore needs to be joined before deleting d_ptr.