### PR TITLE
CMAKE: Remove asio_lib since it is already included earlier.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,7 +431,7 @@ target_include_directories(lspcpp PRIVATE ${LSP_INCLUDE_LIST})
 
 target_link_libraries(
         lspcpp
-        PUBLIC ${LSPCPP_EXTERNAL_LIBS} network-uri asio_lib
+        PUBLIC ${LSPCPP_EXTERNAL_LIBS} network-uri
 )
 
 set(LSPCPP_THIRD_PARTY_DIR_LIST


### PR DESCRIPTION
This is a minor PR to fix my previous PR for switching to C++17 and setting up git subrepo.